### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache-dependency-path: go.mod
           check-latest: true
 
       - name: Verify formatting


### PR DESCRIPTION
Refresh GitHub Actions versions to remove the Node.js 20 deprecation warning and explicitly point Go module caching at go.mod.

Changes:
- update actions/checkout to v6
- update actions/setup-go to v6
- set cache-dependency-path to go.mod