### PR TITLE
Add agent demo onboarding command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses pre-1.0 semantic versioning tags.
 
 ## [Unreleased]
+### Added
+- `agent demo` subcommand for a safe read-only onboarding flow that runs `doctor`, lists live MCP tools, calls `XcodeListWindows`, and prints suggested next commands.
+
+### Changed
+- Improved first-run onboarding docs and root CLI help with a faster demo-oriented path for humans and agents.
 
 ## [0.2.1] - 2026-03-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ Running `xcodemcp` with no arguments prints help. Use `bridge` for raw passthrou
 ./xcodemcp bridge --session-id 11111111-1111-1111-1111-111111111111
 ```
 
+Fastest safe live onboarding demo:
+
+```bash
+./xcodemcp agent demo
+./xcodemcp agent demo --json
+```
+
+`agent demo` is read-only. It reuses `doctor`, discovers the live tool catalog, safely calls `XcodeListWindows`, and prints the next commands to try.
+
 Run environment diagnostics:
 
 ```bash
@@ -79,11 +88,28 @@ printf '{}' | ./xcodemcp tool call XcodeListWindows --json-stdin
 Inspect the LaunchAgent used by `tools` commands:
 
 ```bash
+./xcodemcp agent demo
 ./xcodemcp agent status
 ./xcodemcp agent status --json
 ./xcodemcp agent stop
 ./xcodemcp agent uninstall
 ```
+
+## LLM agent example flow
+
+If you want one concrete end-to-end sequence for a shell-driven agent:
+
+```bash
+./xcodemcp agent demo
+./xcodemcp tool inspect XcodeRead --json
+./xcodemcp tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'
+./xcodemcp tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'
+```
+
+Notes:
+- Many Xcode MCP tools require a `tabIdentifier`.
+- `XcodeListWindows` is the normal way to discover that value.
+- `agent demo` runs `XcodeListWindows` safely and shows the next commands with placeholders.
 
 ## Agent onboarding
 

--- a/cmd/xcodemcp/agent_demo.go
+++ b/cmd/xcodemcp/agent_demo.go
@@ -1,0 +1,381 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
+	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
+	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
+)
+
+const demoWindowsToolName = "XcodeListWindows"
+
+var demoHighlightToolNames = []string{
+	demoWindowsToolName,
+	"XcodeLS",
+	"XcodeRead",
+	"BuildProject",
+	"RunAllTests",
+}
+
+type demoStepError struct {
+	Step    string `json:"step"`
+	Message string `json:"message"`
+}
+
+type demoToolHighlight struct {
+	Name         string   `json:"name"`
+	Description  string   `json:"description"`
+	RequiredArgs []string `json:"requiredArgs"`
+}
+
+type demoToolCatalog struct {
+	Count      int                 `json:"count"`
+	Names      []string            `json:"names"`
+	Highlights []demoToolHighlight `json:"highlights"`
+}
+
+type demoWindowsResult struct {
+	Attempted bool           `json:"attempted"`
+	Ok        bool           `json:"ok"`
+	ToolName  string         `json:"toolName"`
+	Arguments map[string]any `json:"arguments"`
+	Result    map[string]any `json:"result"`
+	Error     *demoStepError `json:"error"`
+}
+
+type agentDemoReport struct {
+	Success      bool              `json:"success"`
+	Doctor       doctor.JSONReport `json:"doctor"`
+	AgentStatus  *agent.Status     `json:"agentStatus"`
+	ToolCatalog  demoToolCatalog   `json:"toolCatalog"`
+	WindowsDemo  demoWindowsResult `json:"windowsDemo"`
+	NextCommands []string          `json:"nextCommands"`
+	Errors       []demoStepError   `json:"errors"`
+}
+
+func runAgentDemo(ctx context.Context, cfg cliConfig, env []string, stdout, stderr io.Writer, agentCfg agent.Config) int {
+	resolved, err := resolveEffectiveOptions(env, cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+		return 1
+	}
+	if cfg.Debug {
+		logResolvedSession(stderr, resolved)
+	}
+	effective := resolved.EnvOptions
+	if err := bridge.ValidateEnvOptions(effective); err != nil {
+		fmt.Fprintf(stderr, "xcodemcp: invalid MCP options: %v\n", err)
+		return 1
+	}
+
+	initialStatus, initialStatusErr := defaultAgentStatusFunc(ctx, agentCfg)
+	doctorReport := defaultDoctorRunFunc(ctx, doctor.Options{
+		BaseEnv:        env,
+		XcodePID:       resolved.XcodePID,
+		SessionID:      resolved.SessionID,
+		SessionSource:  resolved.SessionSource,
+		SessionPath:    resolved.SessionPath,
+		AgentStatus:    agentStatusPointer(initialStatus, initialStatusErr),
+		AgentStatusErr: initialStatusErr,
+	})
+
+	report := agentDemoReport{
+		Doctor: doctorReport.JSON(),
+		ToolCatalog: demoToolCatalog{
+			Names:      []string{},
+			Highlights: []demoToolHighlight{},
+		},
+		WindowsDemo: demoWindowsResult{
+			ToolName:  demoWindowsToolName,
+			Arguments: map[string]any{},
+		},
+		NextCommands: agentDemoNextCommands(),
+		Errors:       []demoStepError{},
+	}
+
+	request := agentRequest(env, effective, cfg)
+
+	toolsCtx, cancelTools := requestTimeoutContext(ctx, cfg.Timeout)
+	tools, toolsErr := defaultToolsListFunc(toolsCtx, agentCfg, request)
+	cancelTools()
+	if toolsErr != nil {
+		report.addError("tools list", toolsErr.Error())
+	} else {
+		report.ToolCatalog = buildDemoToolCatalog(tools)
+	}
+
+	postToolsStatus, postToolsStatusErr := defaultAgentStatusFunc(ctx, agentCfg)
+	if postToolsStatusErr != nil {
+		report.addError("agent status", postToolsStatusErr.Error())
+	} else {
+		report.AgentStatus = &postToolsStatus
+	}
+
+	if toolsErr == nil {
+		if _, found := findToolByName(tools, demoWindowsToolName); !found {
+			report.WindowsDemo.Error = &demoStepError{Step: "windows demo", Message: "tool not found: XcodeListWindows"}
+			report.addError("windows demo", "tool not found: XcodeListWindows")
+		} else {
+			report.WindowsDemo.Attempted = true
+			callCtx, cancelCall := requestTimeoutContext(ctx, cfg.Timeout)
+			result, callErr := defaultToolCallFunc(callCtx, agentCfg, request, demoWindowsToolName, report.WindowsDemo.Arguments)
+			cancelCall()
+			if callErr != nil {
+				report.WindowsDemo.Error = &demoStepError{Step: "windows demo", Message: callErr.Error()}
+				report.addError("windows demo", callErr.Error())
+			} else {
+				report.WindowsDemo.Result = result.Result
+				report.WindowsDemo.Ok = !result.IsError
+				if result.IsError {
+					message := extractDemoToolMessage(result.Result)
+					if message == "" {
+						message = "tool returned isError=true"
+					}
+					report.WindowsDemo.Error = &demoStepError{Step: "windows demo", Message: message}
+					report.addError("windows demo", message)
+				}
+			}
+		}
+	}
+
+	report.Success = doctorReport.Success() && toolsErr == nil && report.WindowsDemo.Attempted && report.WindowsDemo.Ok
+
+	if cfg.JSONOutput {
+		if err := writeJSON(stdout, report); err != nil {
+			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			return 1
+		}
+	} else {
+		fmt.Fprint(stdout, formatAgentDemo(report))
+	}
+
+	if report.Success {
+		return 0
+	}
+	return 1
+}
+
+func agentStatusPointer(status agent.Status, err error) *agent.Status {
+	if err != nil {
+		return nil
+	}
+	return &status
+}
+
+func (r *agentDemoReport) addError(step, message string) {
+	r.Errors = append(r.Errors, demoStepError{Step: step, Message: message})
+}
+
+func buildDemoToolCatalog(tools []map[string]any) demoToolCatalog {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		if name, _ := tool["name"].(string); name != "" {
+			names = append(names, name)
+		}
+	}
+
+	highlights := make([]demoToolHighlight, 0, len(demoHighlightToolNames))
+	for _, name := range demoHighlightToolNames {
+		tool, found := findToolByName(tools, name)
+		if !found {
+			continue
+		}
+		highlights = append(highlights, demoToolHighlight{
+			Name:         name,
+			Description:  stringValue(tool["description"]),
+			RequiredArgs: requiredArgsFromTool(tool),
+		})
+	}
+
+	return demoToolCatalog{
+		Count:      len(names),
+		Names:      names,
+		Highlights: highlights,
+	}
+}
+
+func requiredArgsFromTool(tool map[string]any) []string {
+	inputSchema, ok := tool["inputSchema"].(map[string]any)
+	if !ok {
+		return []string{}
+	}
+	rawRequired, ok := inputSchema["required"]
+	if !ok {
+		return []string{}
+	}
+	switch values := rawRequired.(type) {
+	case []string:
+		return append([]string{}, values...)
+	case []any:
+		required := make([]string, 0, len(values))
+		for _, value := range values {
+			if str, ok := value.(string); ok && str != "" {
+				required = append(required, str)
+			}
+		}
+		return required
+	default:
+		return []string{}
+	}
+}
+
+func agentDemoNextCommands() []string {
+	return []string{
+		`xcodemcp tool inspect XcodeRead --json`,
+		`xcodemcp tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'`,
+		`xcodemcp tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'`,
+	}
+}
+
+func formatAgentDemo(report agentDemoReport) string {
+	var b strings.Builder
+	b.WriteString("xcodemcp agent demo\n\n")
+
+	b.WriteString("Environment\n")
+	b.WriteString("-----------\n")
+	doctorSummary := report.Doctor.Summary
+	doctorState := "ok"
+	if !report.Doctor.Success {
+		doctorState = "needs attention"
+	}
+	fmt.Fprintf(&b, "doctor: %s (%d ok, %d warn, %d fail, %d info)\n", doctorState, doctorSummary.OK, doctorSummary.Warn, doctorSummary.Fail, doctorSummary.Info)
+	notableChecks := doctorNotableChecks(report.Doctor)
+	if len(notableChecks) > 0 {
+		b.WriteString("notable checks:\n")
+		for _, check := range notableChecks {
+			fmt.Fprintf(&b, "- %s [%s]: %s\n", check.Name, check.Status, check.Detail)
+		}
+	}
+	if report.AgentStatus != nil {
+		fmt.Fprintf(&b, "launchagent after tools discovery: running=%t socketReachable=%t backendSessions=%d\n", report.AgentStatus.Running, report.AgentStatus.SocketReachable, report.AgentStatus.BackendSessions)
+	} else {
+		b.WriteString("launchagent after tools discovery: unavailable\n")
+	}
+	if err := findDemoError(report.Errors, "agent status"); err != nil {
+		fmt.Fprintf(&b, "agent status note: %s\n", err.Message)
+	}
+
+	b.WriteString("\nTool Catalog\n")
+	b.WriteString("------------\n")
+	fmt.Fprintf(&b, "count: %d\n", report.ToolCatalog.Count)
+	if len(report.ToolCatalog.Names) > 0 {
+		fmt.Fprintf(&b, "names: %s\n", strings.Join(report.ToolCatalog.Names, ", "))
+	} else {
+		b.WriteString("names: unavailable\n")
+	}
+	if len(report.ToolCatalog.Highlights) > 0 {
+		b.WriteString("highlights:\n")
+		for _, highlight := range report.ToolCatalog.Highlights {
+			required := "none"
+			if len(highlight.RequiredArgs) > 0 {
+				required = strings.Join(highlight.RequiredArgs, ", ")
+			}
+			fmt.Fprintf(&b, "- %s (required: %s): %s\n", highlight.Name, required, highlight.Description)
+		}
+	}
+	if err := findDemoError(report.Errors, "tools list"); err != nil {
+		fmt.Fprintf(&b, "catalog error: %s\n", err.Message)
+	}
+
+	b.WriteString("\nSafe Live Demo\n")
+	b.WriteString("--------------\n")
+	fmt.Fprintf(&b, "tool: %s --json '{}'\n", report.WindowsDemo.ToolName)
+	switch {
+	case report.WindowsDemo.Ok:
+		b.WriteString("status: ok\n")
+		if message := extractDemoToolMessage(report.WindowsDemo.Result); message != "" {
+			b.WriteString("output:\n")
+			b.WriteString(indentText(message, "  "))
+			if !strings.HasSuffix(message, "\n") {
+				b.WriteString("\n")
+			}
+		}
+	case report.WindowsDemo.Attempted:
+		b.WriteString("status: failed\n")
+		if report.WindowsDemo.Error != nil {
+			fmt.Fprintf(&b, "error: %s\n", report.WindowsDemo.Error.Message)
+		}
+	default:
+		b.WriteString("status: skipped\n")
+		if report.WindowsDemo.Error != nil {
+			fmt.Fprintf(&b, "reason: %s\n", report.WindowsDemo.Error.Message)
+		}
+	}
+
+	b.WriteString("\nNext Commands\n")
+	b.WriteString("-------------\n")
+	for _, command := range report.NextCommands {
+		fmt.Fprintf(&b, "- %s\n", command)
+	}
+
+	return b.String()
+}
+
+func doctorNotableChecks(report doctor.JSONReport) []doctor.Check {
+	checks := make([]doctor.Check, 0, len(report.Checks))
+	for _, check := range report.Checks {
+		if check.Status == doctor.StatusOK {
+			continue
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}
+
+func findDemoError(errors []demoStepError, step string) *demoStepError {
+	for i := range errors {
+		if errors[i].Step == step {
+			return &errors[i]
+		}
+	}
+	return nil
+}
+
+func extractDemoToolMessage(result map[string]any) string {
+	if result == nil {
+		return ""
+	}
+	if structured, ok := result["structuredContent"].(map[string]any); ok {
+		if message, ok := structured["message"].(string); ok && strings.TrimSpace(message) != "" {
+			return message
+		}
+	}
+	if content, ok := result["content"].([]any); ok {
+		messages := make([]string, 0, len(content))
+		for _, item := range content {
+			block, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := block["text"].(string); ok && strings.TrimSpace(text) != "" {
+				messages = append(messages, text)
+			}
+		}
+		if len(messages) > 0 {
+			return strings.Join(messages, "\n")
+		}
+	}
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, result); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func indentText(text, prefix string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+func stringValue(value any) string {
+	str, _ := value.(string)
+	return str
+}

--- a/cmd/xcodemcp/agent_demo_test.go
+++ b/cmd/xcodemcp/agent_demo_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
+	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
+	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+)
+
+func TestParseCLIAgentDemo(t *testing.T) {
+	cfg, _, err := parseCLI([]string{"agent", "demo", "--json", "--timeout", "45s", "--xcode-pid", "123", "--debug"})
+	if err != nil {
+		t.Fatalf("parseCLI returned error: %v", err)
+	}
+	if cfg.Command != commandAgentDemo {
+		t.Fatalf("command = %q, want %q", cfg.Command, commandAgentDemo)
+	}
+	if !cfg.JSONOutput || cfg.Timeout.String() != "45s" || cfg.XcodePID != "123" || !cfg.Debug {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestParseCLIHelpAgentDemo(t *testing.T) {
+	_, usage, err := parseCLI([]string{"help", "agent", "demo"})
+	if err != errUsageRequested {
+		t.Fatalf("err = %v, want errUsageRequested", err)
+	}
+	if !strings.Contains(usage, "agent demo") {
+		t.Fatalf("usage missing agent demo help: %q", usage)
+	}
+}
+
+func TestRootUsageIncludesAgentDemo(t *testing.T) {
+	usage := rootUsage()
+	for _, want := range []string{"xcodemcp agent demo", "xcodemcp tools list", "xcodemcp tool call XcodeListWindows --json '{}'"} {
+		if !strings.Contains(usage, want) {
+			t.Fatalf("root usage missing %q: %s", want, usage)
+		}
+	}
+}
+
+func TestAgentUsageIncludesDemo(t *testing.T) {
+	usage := agentUsage()
+	for _, want := range []string{"xcodemcp agent demo", "demo         Run a safe read-only onboarding demo"} {
+		if !strings.Contains(usage, want) {
+			t.Fatalf("agent usage missing %q: %s", want, usage)
+		}
+	}
+}
+
+func TestRunAgentDemoText(t *testing.T) {
+	withStubs(t, func() {
+		defaultDoctorRunFunc = func(ctx context.Context, opts doctor.Options) doctor.Report {
+			return doctor.Report{Checks: []doctor.Check{{Name: "xcrun lookup", Status: doctor.StatusOK, Detail: "/usr/bin/xcrun"}}}
+		}
+
+		agentStatusCalls := 0
+		defaultAgentStatusFunc = func(ctx context.Context, cfg agent.Config) (agent.Status, error) {
+			agentStatusCalls++
+			return agent.Status{Label: agent.LaunchAgentLabel, Running: true, SocketReachable: true, BackendSessions: agentStatusCalls}, nil
+		}
+		defaultToolsListFunc = func(ctx context.Context, cfg agent.Config, req agent.Request) ([]map[string]any, error) {
+			return demoToolFixtures(), nil
+		}
+		defaultToolCallFunc = func(ctx context.Context, cfg agent.Config, req agent.Request, toolName string, arguments map[string]any) (mcp.CallResult, error) {
+			if toolName != demoWindowsToolName {
+				t.Fatalf("toolName = %q, want %q", toolName, demoWindowsToolName)
+			}
+			if len(arguments) != 0 {
+				t.Fatalf("arguments = %+v, want empty object", arguments)
+			}
+			return mcp.CallResult{
+				Result: map[string]any{
+					"structuredContent": map[string]any{"message": "* tabIdentifier: windowtab1, workspacePath: /tmp/Demo.xcodeproj\n"},
+					"content":           []map[string]any{{"type": "text", "text": "* tabIdentifier: windowtab1, workspacePath: /tmp/Demo.xcodeproj\n"}},
+				},
+			}, nil
+		}
+
+		var stdout strings.Builder
+		var stderr strings.Builder
+		code := run(context.Background(), []string{"agent", "demo"}, strings.NewReader(""), &stdout, &stderr, []string{})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+		}
+		text := stdout.String()
+		for _, want := range []string{
+			"Environment",
+			"Tool Catalog",
+			"Safe Live Demo",
+			"Next Commands",
+			"XcodeListWindows",
+			"XcodeLS",
+			"XcodeRead",
+			"xcodemcp tool inspect XcodeRead --json",
+			"* tabIdentifier: windowtab1, workspacePath: /tmp/Demo.xcodeproj",
+			"launchagent after tools discovery: running=true socketReachable=true backendSessions=2",
+		} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("agent demo output missing %q: %s", want, text)
+			}
+		}
+	})
+}
+
+func TestRunAgentDemoJSON(t *testing.T) {
+	withStubs(t, func() {
+		defaultDoctorRunFunc = func(ctx context.Context, opts doctor.Options) doctor.Report {
+			return doctor.Report{Checks: []doctor.Check{{Name: "doctor ok", Status: doctor.StatusOK, Detail: "ok"}}}
+		}
+		defaultAgentStatusFunc = func(ctx context.Context, cfg agent.Config) (agent.Status, error) {
+			return agent.Status{Label: agent.LaunchAgentLabel, Running: true, SocketReachable: true, BackendSessions: 1}, nil
+		}
+		defaultToolsListFunc = func(ctx context.Context, cfg agent.Config, req agent.Request) ([]map[string]any, error) {
+			return demoToolFixtures(), nil
+		}
+		defaultToolCallFunc = func(ctx context.Context, cfg agent.Config, req agent.Request, toolName string, arguments map[string]any) (mcp.CallResult, error) {
+			return mcp.CallResult{Result: map[string]any{"structuredContent": map[string]any{"message": "ok"}}}, nil
+		}
+
+		var stdout strings.Builder
+		var stderr strings.Builder
+		code := run(context.Background(), []string{"agent", "demo", "--json"}, strings.NewReader(""), &stdout, &stderr, []string{})
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0 (stderr=%q)", code, stderr.String())
+		}
+
+		var report agentDemoReport
+		if err := json.Unmarshal([]byte(stdout.String()), &report); err != nil {
+			t.Fatalf("stdout is not JSON report: %v (stdout=%q)", err, stdout.String())
+		}
+		if !report.Success {
+			t.Fatalf("report.Success = false, want true")
+		}
+		if report.AgentStatus == nil || !report.AgentStatus.Running {
+			t.Fatalf("unexpected agent status: %+v", report.AgentStatus)
+		}
+		if report.ToolCatalog.Count != len(demoToolFixtures()) {
+			t.Fatalf("tool count = %d, want %d", report.ToolCatalog.Count, len(demoToolFixtures()))
+		}
+		if len(report.ToolCatalog.Highlights) != 5 {
+			t.Fatalf("len(highlights) = %d, want 5", len(report.ToolCatalog.Highlights))
+		}
+		if !report.WindowsDemo.Attempted || !report.WindowsDemo.Ok {
+			t.Fatalf("unexpected windows demo: %+v", report.WindowsDemo)
+		}
+		if len(report.NextCommands) != 3 {
+			t.Fatalf("len(nextCommands) = %d, want 3", len(report.NextCommands))
+		}
+		if len(report.Errors) != 0 {
+			t.Fatalf("errors = %+v, want empty", report.Errors)
+		}
+	})
+}
+
+func TestRunAgentDemoToolsListFailure(t *testing.T) {
+	withStubs(t, func() {
+		defaultDoctorRunFunc = func(ctx context.Context, opts doctor.Options) doctor.Report {
+			return doctor.Report{Checks: []doctor.Check{{Name: "doctor ok", Status: doctor.StatusOK, Detail: "ok"}}}
+		}
+		defaultAgentStatusFunc = func(ctx context.Context, cfg agent.Config) (agent.Status, error) {
+			return agent.Status{Label: agent.LaunchAgentLabel, Running: true}, nil
+		}
+		defaultToolsListFunc = func(ctx context.Context, cfg agent.Config, req agent.Request) ([]map[string]any, error) {
+			return nil, errors.New("catalog unavailable")
+		}
+
+		var stdout strings.Builder
+		var stderr strings.Builder
+		code := run(context.Background(), []string{"agent", "demo", "--json"}, strings.NewReader(""), &stdout, &stderr, []string{})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		var report agentDemoReport
+		if err := json.Unmarshal([]byte(stdout.String()), &report); err != nil {
+			t.Fatalf("stdout is not JSON report: %v", err)
+		}
+		if report.ToolCatalog.Count != 0 {
+			t.Fatalf("tool count = %d, want 0", report.ToolCatalog.Count)
+		}
+		if report.WindowsDemo.Attempted {
+			t.Fatalf("windows demo attempted = true, want false")
+		}
+		if findDemoError(report.Errors, "tools list") == nil {
+			t.Fatalf("expected tools list error in %+v", report.Errors)
+		}
+	})
+}
+
+func TestRunAgentDemoMissingWindowsTool(t *testing.T) {
+	withStubs(t, func() {
+		defaultDoctorRunFunc = func(ctx context.Context, opts doctor.Options) doctor.Report {
+			return doctor.Report{Checks: []doctor.Check{{Name: "doctor ok", Status: doctor.StatusOK, Detail: "ok"}}}
+		}
+		defaultAgentStatusFunc = func(ctx context.Context, cfg agent.Config) (agent.Status, error) {
+			return agent.Status{Label: agent.LaunchAgentLabel, Running: true}, nil
+		}
+		defaultToolsListFunc = func(ctx context.Context, cfg agent.Config, req agent.Request) ([]map[string]any, error) {
+			return []map[string]any{{"name": "XcodeLS", "description": "List files", "inputSchema": map[string]any{"required": []any{"tabIdentifier", "path"}}}}, nil
+		}
+
+		var stdout strings.Builder
+		var stderr strings.Builder
+		code := run(context.Background(), []string{"agent", "demo", "--json"}, strings.NewReader(""), &stdout, &stderr, []string{})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		var report agentDemoReport
+		if err := json.Unmarshal([]byte(stdout.String()), &report); err != nil {
+			t.Fatalf("stdout is not JSON report: %v", err)
+		}
+		if report.WindowsDemo.Attempted {
+			t.Fatalf("windows demo attempted = true, want false")
+		}
+		if report.WindowsDemo.Error == nil || !strings.Contains(report.WindowsDemo.Error.Message, "tool not found") {
+			t.Fatalf("unexpected windows demo error: %+v", report.WindowsDemo.Error)
+		}
+	})
+}
+
+func TestRunAgentDemoWindowsToolFailure(t *testing.T) {
+	withStubs(t, func() {
+		defaultDoctorRunFunc = func(ctx context.Context, opts doctor.Options) doctor.Report {
+			return doctor.Report{Checks: []doctor.Check{{Name: "doctor ok", Status: doctor.StatusOK, Detail: "ok"}}}
+		}
+		defaultAgentStatusFunc = func(ctx context.Context, cfg agent.Config) (agent.Status, error) {
+			return agent.Status{Label: agent.LaunchAgentLabel, Running: true}, nil
+		}
+		defaultToolsListFunc = func(ctx context.Context, cfg agent.Config, req agent.Request) ([]map[string]any, error) {
+			return demoToolFixtures(), nil
+		}
+		defaultToolCallFunc = func(ctx context.Context, cfg agent.Config, req agent.Request, toolName string, arguments map[string]any) (mcp.CallResult, error) {
+			return mcp.CallResult{}, errors.New("window lookup failed")
+		}
+
+		var stdout strings.Builder
+		var stderr strings.Builder
+		code := run(context.Background(), []string{"agent", "demo", "--json"}, strings.NewReader(""), &stdout, &stderr, []string{})
+		if code != 1 {
+			t.Fatalf("exit code = %d, want 1", code)
+		}
+		var report agentDemoReport
+		if err := json.Unmarshal([]byte(stdout.String()), &report); err != nil {
+			t.Fatalf("stdout is not JSON report: %v", err)
+		}
+		if !report.WindowsDemo.Attempted || report.WindowsDemo.Ok {
+			t.Fatalf("unexpected windows demo state: %+v", report.WindowsDemo)
+		}
+		if report.WindowsDemo.Error == nil || report.WindowsDemo.Error.Message != "window lookup failed" {
+			t.Fatalf("unexpected windows demo error: %+v", report.WindowsDemo.Error)
+		}
+	})
+}
+
+func demoToolFixtures() []map[string]any {
+	return []map[string]any{
+		{
+			"name":        "XcodeListWindows",
+			"description": "List windows",
+			"inputSchema": map[string]any{"type": "object", "required": []any{}},
+		},
+		{
+			"name":        "XcodeLS",
+			"description": "List files",
+			"inputSchema": map[string]any{"type": "object", "required": []any{"tabIdentifier", "path"}},
+		},
+		{
+			"name":        "XcodeRead",
+			"description": "Read files",
+			"inputSchema": map[string]any{"type": "object", "required": []any{"tabIdentifier", "filePath"}},
+		},
+		{
+			"name":        "BuildProject",
+			"description": "Build project",
+			"inputSchema": map[string]any{"type": "object", "required": []any{"tabIdentifier"}},
+		},
+		{
+			"name":        "RunAllTests",
+			"description": "Run tests",
+			"inputSchema": map[string]any{"type": "object", "required": []any{"tabIdentifier"}},
+		},
+	}
+}

--- a/cmd/xcodemcp/cli.go
+++ b/cmd/xcodemcp/cli.go
@@ -20,6 +20,7 @@ const (
 	commandToolCall       commandName = "tool-call"
 	commandToolInspect    commandName = "tool-inspect"
 	commandAgentStatus    commandName = "agent-status"
+	commandAgentDemo      commandName = "agent-demo"
 	commandAgentStop      commandName = "agent-stop"
 	commandAgentUninstall commandName = "agent-uninstall"
 	commandAgentRun       commandName = "agent-run"
@@ -107,6 +108,8 @@ func parseHelp(args []string) (cliConfig, string, error) {
 		}
 		if len(args) == 2 {
 			switch args[1] {
+			case "demo":
+				return cliConfig{}, agentDemoUsage(), errUsageRequested
 			case "status":
 				return cliConfig{}, agentStatusUsage(), errUsageRequested
 			case "stop":
@@ -158,6 +161,10 @@ func parseAgentCLI(args []string) (cliConfig, string, error) {
 		return cliConfig{}, agentUsage(), errUsageRequested
 	}
 	switch args[0] {
+	case "demo":
+		cfg, err := parseAgentDemoFlags("xcodemcp agent demo", args[1:])
+		cfg.Command = commandAgentDemo
+		return cfg, agentDemoUsage(), err
 	case "status":
 		cfg, err := parseAgentStatusFlags("xcodemcp agent status", args[1:])
 		cfg.Command = commandAgentStatus
@@ -325,6 +332,32 @@ func parseAgentStatusFlags(name string, args []string) (cliConfig, error) {
 	return cfg, nil
 }
 
+func parseAgentDemoFlags(name string, args []string) (cliConfig, error) {
+	fs := newFlagSet(name)
+	cfg := cliConfig{Command: commandAgentDemo, Timeout: 30 * time.Second}
+	help := false
+	fs.StringVar(&cfg.XcodePID, "xcode-pid", "", "")
+	fs.StringVar(&cfg.SessionID, "session-id", "", "")
+	fs.BoolVar(&cfg.Debug, "debug", false, "")
+	fs.BoolVar(&cfg.JSONOutput, "json", false, "")
+	fs.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "")
+	fs.BoolVar(&help, "h", false, "")
+	fs.BoolVar(&help, "help", false, "")
+	if err := fs.Parse(args); err != nil {
+		return cliConfig{}, err
+	}
+	if help {
+		return cliConfig{}, errUsageRequested
+	}
+	if cfg.Timeout <= 0 {
+		return cliConfig{}, errors.New("--timeout must be greater than 0")
+	}
+	if fs.NArg() != 0 {
+		return cliConfig{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	return cfg, nil
+}
+
 func parseAgentSimpleFlags(name string, args []string) (cliConfig, error) {
 	fs := newFlagSet(name)
 	cfg := cliConfig{}
@@ -430,13 +463,14 @@ func rootUsage() string {
 
 START HERE:
   For humans:
-    1. xcodemcp doctor --json
-    2. xcodemcp agent status --json
-    3. xcodemcp tools list --json
-    4. xcodemcp tool inspect <name> --json
-    5. xcodemcp tool call <name> --json '{...}'
+    1. xcodemcp agent demo
+    2. xcodemcp doctor --json
+    3. xcodemcp tools list
+    4. xcodemcp tool inspect XcodeListWindows --json
+    5. xcodemcp tool call XcodeListWindows --json '{}'
 
   For agents:
+    - Run a safe live onboarding demo with "xcodemcp agent demo --json".
     - Discover command shapes with "xcodemcp help <command>".
     - Discover runtime health with "xcodemcp doctor --json".
     - Discover LaunchAgent state with "xcodemcp agent status --json".
@@ -456,6 +490,7 @@ USAGE:
   xcodemcp tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
   xcodemcp tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
   xcodemcp tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodemcp agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
   xcodemcp agent status [--json]
   xcodemcp agent stop
   xcodemcp agent uninstall
@@ -587,17 +622,39 @@ NOTES:
 
 func agentUsage() string {
 	return `The agent subcommands inspect or manage the LaunchAgent used by tools commands.
-Use status for diagnostics, stop to end the running process, and uninstall to remove local LaunchAgent state.
+Use demo for a safe read-only onboarding flow, status for diagnostics, stop to end the running process, and uninstall to remove local LaunchAgent state.
 
 USAGE:
+  xcodemcp agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
   xcodemcp agent status [--json]
   xcodemcp agent stop
   xcodemcp agent uninstall
 
 SUBCOMMANDS:
+  demo         Run a safe read-only onboarding demo
   status       Show LaunchAgent installation and runtime state
   stop         Ask the running LaunchAgent process to stop
   uninstall    Remove the LaunchAgent plist and local agent runtime files
+`
+}
+
+func agentDemoUsage() string {
+	return `agent demo runs a safe read-only onboarding flow for first-time humans and agents.
+It reuses doctor output, discovers the live MCP tool catalog, and safely calls XcodeListWindows.
+
+USAGE:
+  xcodemcp agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+
+FLAGS:
+  --json               Print the full demo report as pretty JSON
+  --timeout DURATION   Fail MCP discovery/call steps if they do not finish in time (default 30s)
+  --xcode-pid PID      Override MCP_XCODE_PID
+  --session-id UUID    Override MCP_XCODE_SESSION_ID
+  --debug              Emit convenience-command debug logs to stderr
+  -h, --help           Show help
+
+NOTES:
+  This command is non-mutating. It only runs doctor, tools list, agent status, and XcodeListWindows.
 `
 }
 

--- a/cmd/xcodemcp/main.go
+++ b/cmd/xcodemcp/main.go
@@ -237,6 +237,8 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 			return 1
 		}
 		return 0
+	case commandAgentDemo:
+		return runAgentDemo(ctx, cfg, env, stdout, stderr, agentCfg)
 	case commandAgentStatus:
 		status, err := defaultAgentStatusFunc(ctx, agentCfg)
 		if err != nil {

--- a/cmd/xcodemcp/main_test.go
+++ b/cmd/xcodemcp/main_test.go
@@ -131,7 +131,7 @@ func TestParseCLIHelp(t *testing.T) {
 
 func TestRootUsageIncludesHumanAndAgentGuidance(t *testing.T) {
 	usage := rootUsage()
-	for _, want := range []string{"START HERE:", "For humans:", "For agents:", "xcodemcp doctor --json", "xcodemcp tool inspect <name> --json"} {
+	for _, want := range []string{"START HERE:", "For humans:", "For agents:", "xcodemcp agent demo", "xcodemcp doctor --json", "xcodemcp tool inspect <name> --json"} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("root usage missing %q: %s", want, usage)
 		}

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -9,7 +9,22 @@ cd /Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli
 ./scripts/build.sh
 ```
 
-## 2. Check the environment
+## 2. Fastest safe live demo
+
+```bash
+./xcodemcp agent demo
+./xcodemcp agent demo --json
+```
+
+What this does:
+- runs `doctor`
+- discovers the live MCP tool catalog
+- safely calls `XcodeListWindows`
+- prints the next commands for `XcodeLS` and `XcodeRead`
+
+`agent demo` is read-only. It does **not** build, test, write, update, move, or remove project files.
+
+## 3. Check the environment
 
 ```bash
 ./xcodemcp doctor --json
@@ -21,15 +36,16 @@ Look for:
 - a running Xcode PID or at least an open Xcode process
 - LaunchAgent socket reachability after the first tools command
 
-## 3. Discover available tools
+## 4. Discover available tools
 
 ```bash
+./xcodemcp tools list
 ./xcodemcp tools list --json
 ```
 
 If this is the first `tools` request, `xcodemcp` may install and bootstrap a per-user LaunchAgent automatically.
 
-## 4. Inspect one tool
+## 5. Inspect one tool
 
 ```bash
 ./xcodemcp tool inspect XcodeListWindows
@@ -38,7 +54,7 @@ If this is the first `tools` request, `xcodemcp` may install and bootstrap a per
 
 Use `tool inspect` to confirm the tool name, description, and `inputSchema` before calling it.
 
-## 5. Call a tool
+## 6. Call a tool
 
 Inline JSON:
 
@@ -61,7 +77,19 @@ Read the payload from stdin:
 printf '{}' | ./xcodemcp tool call XcodeListWindows --json-stdin
 ```
 
-## 6. Troubleshooting
+## 7. End-to-end read-only example
+
+Use the `tabIdentifier` returned by `XcodeListWindows` to continue the flow:
+
+```bash
+./xcodemcp tool call XcodeListWindows --json '{}'
+./xcodemcp tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'
+./xcodemcp tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'
+```
+
+If you want the next mutating step after discovery, that is where you would choose something like `BuildProject` or `RunAllTests`.
+
+## 8. Troubleshooting
 
 ### The tool call times out
 - Verify Xcode is open and a workspace/project window is visible.


### PR DESCRIPTION
## Summary
- add a read-only `xcodemcp agent demo` command that runs `doctor`, discovers the live tool catalog, safely calls `XcodeListWindows`, and prints suggested next commands
- update root help, README, and the agent quickstart so first-time humans and shell-driven agents have a clearer demo-first onboarding path
- add parsing/output/failure-path tests for the new command and note the onboarding improvement in the changelog

## Test Plan
- `go test ./cmd/xcodemcp/... ./internal/...`
- `./scripts/build.sh`
- `./xcodemcp help agent demo`
- `./xcodemcp agent demo`

## Risks / Notes
- `agent demo` is intentionally non-mutating and only uses safe discovery commands
- Closes #7
