### PR TITLE
Rename xcodemcp to xcodecli

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,5 +23,5 @@ assignees: ''
 ## Environment
 - macOS version:
 - Xcode version:
-- `xcodemcp` commit/version:
+- `xcodecli` commit/version:
 - Additional context:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         run: go test ./...
 
       - name: Build CLI
-        run: ./scripts/build.sh .tmp/xcodemcp
+        run: ./scripts/build.sh .tmp/xcodecli

--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag to publish to Homebrew (for example v0.2.1)
+        description: Release tag to publish to Homebrew (for example v0.3.0)
         required: true
         type: string
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 
 # Go build outputs
-/xcodemcp
+/xcodecli
 *.test
 *.out
 coverage.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agent quick rules for `xcodemcp`
+# Agent quick rules for `xcodecli`
 
 Use this repository when you need a CLI bridge into Xcode's MCP tools.
 
@@ -6,14 +6,14 @@ Use this repository when you need a CLI bridge into Xcode's MCP tools.
 - macOS only.
 - Xcode must be running.
 - At least one workspace or project window should be open in Xcode before using `tools` commands.
-- The first `tools` request may automatically install a LaunchAgent at `~/Library/LaunchAgents/io.oozoofrog.xcodemcp.plist`.
+- The first `tools` request may automatically install a LaunchAgent at `~/Library/LaunchAgents/io.oozoofrog.xcodecli.plist`.
 
 ## Recommended first-time flow
-1. `./xcodemcp agent guide "build Unicody"`
-2. `./xcodemcp agent demo --json`
-3. `./xcodemcp doctor --json`
-4. `./xcodemcp tools list --json`
-5. `./xcodemcp tool call <name> --json '{...}'`
+1. `./xcodecli agent guide "build Unicody"`
+2. `./xcodecli agent demo --json`
+3. `./xcodecli doctor --json`
+4. `./xcodecli tools list --json`
+5. `./xcodecli tool call <name> --json '{...}'`
 
 ## Workflow guidance first
 - Start with `agent guide` when you already know the user's intent and need to learn the right tool sequence.
@@ -27,5 +27,5 @@ Use this repository when you need a CLI bridge into Xcode's MCP tools.
 
 ## Failure triage
 - Retry with `--debug` on `tools list`, `tool inspect`, or `tool call`.
-- Check `./xcodemcp agent status --json` for LaunchAgent installation, socket reachability, and backend session state.
-- If the agent is wedged, run `./xcodemcp agent stop` or `./xcodemcp agent uninstall` and retry.
+- Check `./xcodecli agent status --json` for LaunchAgent installation, socket reachability, and backend session state.
+- If the agent is wedged, run `./xcodecli agent stop` or `./xcodecli agent uninstall` and retry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 ### Added
-- `agent guide` subcommand for read-only workflow tutoring that maps a request to the recommended xcodemcp tool sequence and prints exact next commands.
+- `agent guide` subcommand for read-only workflow tutoring that maps a request to the recommended xcodecli tool sequence and prints exact next commands.
 - `agent demo` subcommand for a safe read-only onboarding flow that runs `doctor`, lists live MCP tools, calls `XcodeListWindows`, and prints suggested next commands.
-- `scripts/install.sh` for installing `xcodemcp` from a local checkout or directly from GitHub source refs.
+- `scripts/install.sh` for installing `xcodecli` from a local checkout or directly from GitHub source refs.
+- Legacy session migration from `~/Library/Application Support/xcodemcp/session-id` into the new `xcodecli` runtime location.
 
 ### Changed
+- **Breaking rename:** the project, GitHub repository, CLI binary, LaunchAgent runtime identifiers, and Homebrew formula all move from `xcodemcp` to `xcodecli`.
 - Improved first-run onboarding docs and root CLI help with a guide-first path for humans and agents, while keeping `agent demo` as the safe live discovery step.
 - Moved installation guidance near the top of the README and documented both direct GitHub installs and Homebrew installs.
-- `scripts/install.sh` now verifies PATH reachability for the user's login shell and prints shell-specific next steps when `xcodemcp` is not discoverable on PATH.
+- `scripts/install.sh` now verifies PATH reachability for the user's login shell and prints shell-specific next steps when `xcodecli` is not discoverable on PATH.
+- `agent status`, `doctor`, and `agent uninstall` now detect and clean up legacy `xcodemcp` LaunchAgent/support artifacts.
+- Homebrew release automation now publishes `oozoofrog/tap/xcodecli` and removes the legacy `xcodemcp` formula during the rename cutover.
 
 ## [0.2.1] - 2026-03-14
 ### Added
@@ -25,13 +29,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - MCP convenience commands: `tools list`, `tool inspect`, and `tool call`.
 - LaunchAgent-backed runtime for long-lived `mcpbridge` sessions used by tools commands.
 - Persistent `MCP_XCODE_SESSION_ID` reuse across runs.
-- First-time agent onboarding docs in `/Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli/AGENTS.md` and `/Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli/docs/agent-quickstart.md`.
+- First-time agent onboarding docs in `AGENTS.md` and `docs/agent-quickstart.md`.
 - JSON output modes for `doctor` and `agent status`.
 - `tool call` payload input via inline JSON, `@file`, and `--json-stdin`.
 - `scripts/build.sh` for repeatable local builds.
 
 ### Changed
-- `xcodemcp` with no arguments now prints help instead of defaulting to raw bridge execution.
+- `xcodecli` with no arguments now prints help instead of defaulting to raw bridge execution.
 - CLI help now includes richer guidance for both humans and agents.
 - Tool command startup and LaunchAgent autostart now honor request timeouts.
 - Agent-only commands no longer create a persistent session file as a side effect.
@@ -47,7 +51,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [0.1.0] - 2026-03-13
 ### Added
-- Initial Go-based `xcodemcp` CLI scaffold.
+- Initial Go-based `xcodecli` CLI scaffold.
 - Raw `bridge` mode for passthrough execution of `xcrun mcpbridge`.
 - `doctor` command for local environment diagnostics.
 - Project metadata, LICENSE, CI, and collaboration templates.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xcodemcp
+# xcodecli
 
-`xcodemcp` is a small Go wrapper around `xcrun mcpbridge` for local macOS use.
+`xcodecli` is a small Go wrapper around `xcrun mcpbridge` for local macOS use.
 
 ## Install
 
@@ -10,14 +10,14 @@ Install from the shared `oozoofrog/tap` formula:
 
 ```bash
 brew tap oozoofrog/tap
-brew install oozoofrog/tap/xcodemcp
+brew install oozoofrog/tap/xcodecli
 ```
 
 Upgrade later with:
 
 ```bash
 brew update
-brew upgrade oozoofrog/tap/xcodemcp
+brew upgrade oozoofrog/tap/xcodecli
 ```
 
 ### Direct install from GitHub
@@ -25,20 +25,20 @@ brew upgrade oozoofrog/tap/xcodemcp
 Install the current `main` branch directly from GitHub:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodemcp-cli/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodecli/main/scripts/install.sh | bash
 ```
 
 Install a specific tag or branch:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodemcp-cli/main/scripts/install.sh | bash -s -- --ref v0.2.1
-curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodemcp-cli/main/scripts/install.sh | bash -s -- --ref main
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodecli/main/scripts/install.sh | bash -s -- --ref v0.3.0
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodecli/main/scripts/install.sh | bash -s -- --ref main
 ```
 
 Install into a custom directory:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodemcp-cli/main/scripts/install.sh | bash -s -- --bin-dir "$HOME/.local/bin"
+curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodecli/main/scripts/install.sh | bash -s -- --bin-dir "$HOME/.local/bin"
 ```
 
 ### Install from a local checkout
@@ -53,44 +53,51 @@ Build and install from the checked-out repository:
 The install script:
 - builds from the current checkout when run locally
 - downloads and builds the requested GitHub ref when run via `curl | bash`
-- installs `xcodemcp` into `$HOME/.local/bin` by default
+- installs `xcodecli` into `$HOME/.local/bin` by default
 - verifies that the installed binary runs successfully
-- checks whether your login shell can find `xcodemcp` on `PATH` and prints shell-specific guidance if it cannot
+- checks whether your login shell can find `xcodecli` on `PATH` and prints shell-specific guidance if it cannot
 
-The shared `oozoofrog/tap` repository can host multiple formulas and casks. `xcodemcp` is published there as `Formula/xcodemcp.rb`.
+The shared `oozoofrog/tap` repository can host multiple formulas and casks. `xcodecli` is published there as `Formula/xcodecli.rb`.
 
-If a release needs to be synced manually, see `/Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli/docs/releasing.md` and `./scripts/release_homebrew.sh`.
+If you are upgrading from the old `xcodemcp` name, switch with:
+
+```bash
+brew uninstall xcodemcp || true
+brew install oozoofrog/tap/xcodecli
+```
+
+If a release needs to be synced manually, see `docs/releasing.md` and `./scripts/release_homebrew.sh`.
 
 ## Build from source
 
 ```bash
 ./scripts/build.sh
-./scripts/build.sh .tmp/xcodemcp
+./scripts/build.sh .tmp/xcodecli
 ```
 
 You can also override the package or output path:
 
 ```bash
-OUTPUT=.tmp/xcodemcp ./scripts/build.sh
-PACKAGE=./cmd/xcodemcp ./scripts/build.sh
+OUTPUT=.tmp/xcodecli ./scripts/build.sh
+PACKAGE=./cmd/xcodecli ./scripts/build.sh
 ```
 
 ## Usage
 
-Running `xcodemcp` with no arguments prints help. Use `bridge` for raw passthrough to `xcrun mcpbridge`.
+Running `xcodecli` with no arguments prints help. Use `bridge` for raw passthrough to `xcrun mcpbridge`.
 
 ```bash
-./xcodemcp
-./xcodemcp --xcode-pid 12345
-./xcodemcp bridge --session-id 11111111-1111-1111-1111-111111111111
+./xcodecli
+./xcodecli --xcode-pid 12345
+./xcodecli bridge --session-id 11111111-1111-1111-1111-111111111111
 ```
 
 Fastest workflow tutor for a real request:
 
 ```bash
-./xcodemcp agent guide "build Unicody"
-./xcodemcp agent guide "read KeyboardState.swift"
-./xcodemcp agent guide --json
+./xcodecli agent guide "build Unicody"
+./xcodecli agent guide "read KeyboardState.swift"
+./xcodecli agent guide --json
 ```
 
 `agent guide` is read-only. It maps a user request to the recommended tool workflow, shows why that order is correct, and prints the exact next commands to run.
@@ -98,8 +105,8 @@ Fastest workflow tutor for a real request:
 Fastest safe live onboarding demo:
 
 ```bash
-./xcodemcp agent demo
-./xcodemcp agent demo --json
+./xcodecli agent demo
+./xcodecli agent demo --json
 ```
 
 `agent demo` is read-only. It reuses `doctor`, discovers the live tool catalog, safely calls `XcodeListWindows`, and prints the next commands to try.
@@ -107,42 +114,42 @@ Fastest safe live onboarding demo:
 Run environment diagnostics:
 
 ```bash
-./xcodemcp doctor
-./xcodemcp doctor --json
-MCP_XCODE_PID=12345 ./xcodemcp doctor --json
+./xcodecli doctor
+./xcodecli doctor --json
+MCP_XCODE_PID=12345 ./xcodecli doctor --json
 ```
 
 List tools through the MCP bridge:
 
 ```bash
-./xcodemcp tools list
-./xcodemcp tools list --json --timeout 30s
+./xcodecli tools list
+./xcodecli tools list --json --timeout 30s
 ```
 
 Inspect a single tool before calling it:
 
 ```bash
-./xcodemcp tool inspect XcodeListWindows
-./xcodemcp tool inspect XcodeListWindows --json
+./xcodecli tool inspect XcodeListWindows
+./xcodecli tool inspect XcodeListWindows --json
 ```
 
 Call a single tool with JSON arguments:
 
 ```bash
-./xcodemcp tool call XcodeListWindows --json '{}'
-./xcodemcp tool call BuildProject --json @/tmp/payload.json
-printf '{}' | ./xcodemcp tool call XcodeListWindows --json-stdin
+./xcodecli tool call XcodeListWindows --json '{}'
+./xcodecli tool call BuildProject --json @/tmp/payload.json
+printf '{}' | ./xcodecli tool call XcodeListWindows --json-stdin
 ```
 
 Inspect the LaunchAgent used by `tools` commands:
 
 ```bash
-./xcodemcp agent guide "build Unicody"
-./xcodemcp agent demo
-./xcodemcp agent status
-./xcodemcp agent status --json
-./xcodemcp agent stop
-./xcodemcp agent uninstall
+./xcodecli agent guide "build Unicody"
+./xcodecli agent demo
+./xcodecli agent status
+./xcodecli agent status --json
+./xcodecli agent stop
+./xcodecli agent uninstall
 ```
 
 ## LLM agent workflow playbook
@@ -150,12 +157,12 @@ Inspect the LaunchAgent used by `tools` commands:
 Start here when you already know the task:
 
 ```bash
-./xcodemcp agent guide "build Unicody"
-./xcodemcp agent guide "run tests for Unicody"
-./xcodemcp agent guide "read KeyboardState.swift"
-./xcodemcp agent guide "search for AdManager"
-./xcodemcp agent guide "update KeyboardState.swift"
-./xcodemcp agent guide "diagnose build errors"
+./xcodecli agent guide "build Unicody"
+./xcodecli agent guide "run tests for Unicody"
+./xcodecli agent guide "read KeyboardState.swift"
+./xcodecli agent guide "search for AdManager"
+./xcodecli agent guide "update KeyboardState.swift"
+./xcodecli agent guide "diagnose build errors"
 ```
 
 Notes:
@@ -169,18 +176,18 @@ Notes:
 If you want the raw building blocks instead of guidance:
 
 ```bash
-./xcodemcp tools list
-./xcodemcp tool inspect XcodeListWindows --json
-./xcodemcp tool call XcodeListWindows --json '{}'
-./xcodemcp tool call BuildProject --json '{"tabIdentifier":"<tabIdentifier from above>"}'
+./xcodecli tools list
+./xcodecli tool inspect XcodeListWindows --json
+./xcodecli tool call XcodeListWindows --json '{}'
+./xcodecli tool call BuildProject --json '{"tabIdentifier":"<tabIdentifier from above>"}'
 ```
 
 After `agent guide` and `agent demo`, the next likely usability improvement is a higher-level task command. This repository does **not** add that abstraction yet.
 
 ## Agent onboarding
 
-- Quick rules for first-time agents: `/Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli/AGENTS.md`
-- Detailed walkthrough: `/Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli/docs/agent-quickstart.md`
+- Quick rules for first-time agents: `AGENTS.md`
+- Detailed walkthrough: `docs/agent-quickstart.md`
 
 ## Git workflow
 
@@ -191,21 +198,23 @@ After `agent guide` and `agent demo`, the next likely usability improvement is a
 
 ## Versioning strategy
 
-Starting after `v0.2.0`, the project will continue to use pre-1.0 semantic versioning tags with the following release policy:
+Starting with the `xcodecli` rename release, the project continues to use pre-1.0 semantic versioning tags with the following release policy:
 
 - `v0.2.1`, `v0.2.2`, ...: patch releases for bug fixes, CI/test hardening, documentation corrections, and internal refactors that do not intentionally expand the public CLI surface.
 - `v0.3.0`, `v0.4.0`, ...: minor releases for new commands, new flags, new output modes, default-behavior expansions, or materially new LaunchAgent / MCP capabilities.
 - Breaking CLI behavior is avoided when possible. Before `v1.0.0`, any unavoidable breaking change should ship in a new minor release and must be called out explicitly in `CHANGELOG.md` and the GitHub Release notes.
 - Releases should be cut from `main` only after CI is green.
 - Tags should remain annotated `vMAJOR.MINOR.PATCH` tags, and GitHub Releases should continue to use generated notes unless a release needs hand-written upgrade guidance.
-- The active maintenance line after this release is `v0.2.x`. Small fixes should prefer the next patch tag on that line before opening a new minor series.
+- The active maintenance line after this breaking rename is `v0.3.x`. Small fixes should prefer the next patch tag on that line before opening a new minor series.
 
 ## Notes
 
 - `--xcode-pid` overrides `MCP_XCODE_PID`.
 - `--session-id` overrides `MCP_XCODE_SESSION_ID`.
-- If no `--session-id` flag or `MCP_XCODE_SESSION_ID` environment variable is provided, `xcodemcp` automatically creates and reuses a persistent session ID at `~/Library/Application Support/xcodemcp/session-id`.
+- If no `--session-id` flag or `MCP_XCODE_SESSION_ID` environment variable is provided, `xcodecli` automatically creates and reuses a persistent session ID at `~/Library/Application Support/xcodecli/session-id`.
+- If an older `~/Library/Application Support/xcodemcp/session-id` exists, `xcodecli` copies it once into the new `xcodecli` location.
 - In bridge mode, **stdout is protocol-only**. Wrapper logs and diagnostics go to stderr.
-- Convenience commands (`tools list`, `tool inspect`, `tool call`) automatically install and bootstrap a per-user LaunchAgent at `~/Library/LaunchAgents/io.oozoofrog.xcodemcp.plist`.
+- Convenience commands (`tools list`, `tool inspect`, `tool call`) automatically install and bootstrap a per-user LaunchAgent at `~/Library/LaunchAgents/io.oozoofrog.xcodecli.plist`.
+- `xcodecli agent status` and `xcodecli doctor` also report whether legacy `xcodemcp` LaunchAgent/support artifacts are still present.
 - The LaunchAgent talks to `xcrun mcpbridge` over a long-lived local Unix socket and shuts itself down after `10m` of idleness by default.
 - `tool call` accepts exactly one payload source: inline `--json`, `--json @file`, or `--json-stdin`.

--- a/cmd/xcodecli/agent_demo.go
+++ b/cmd/xcodecli/agent_demo.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
-	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/doctor"
 )
 
 const demoWindowsToolName = "XcodeListWindows"
@@ -61,7 +61,7 @@ type agentDemoReport struct {
 func runAgentDemo(ctx context.Context, cfg cliConfig, env []string, stdout, stderr io.Writer, agentCfg agent.Config) int {
 	resolved, err := resolveEffectiveOptions(env, cfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+		fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 		return 1
 	}
 	if cfg.Debug {
@@ -69,7 +69,7 @@ func runAgentDemo(ctx context.Context, cfg cliConfig, env []string, stdout, stde
 	}
 	effective := resolved.EnvOptions
 	if err := bridge.ValidateEnvOptions(effective); err != nil {
-		fmt.Fprintf(stderr, "xcodemcp: invalid MCP options: %v\n", err)
+		fmt.Fprintf(stderr, "xcodecli: invalid MCP options: %v\n", err)
 		return 1
 	}
 
@@ -147,7 +147,7 @@ func runAgentDemo(ctx context.Context, cfg cliConfig, env []string, stdout, stde
 
 	if cfg.JSONOutput {
 		if err := writeJSON(stdout, report); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 	} else {
@@ -226,15 +226,15 @@ func requiredArgsFromTool(tool map[string]any) []string {
 
 func agentDemoNextCommands() []string {
 	return []string{
-		`xcodemcp tool inspect XcodeRead --json`,
-		`xcodemcp tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'`,
-		`xcodemcp tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'`,
+		`xcodecli tool inspect XcodeRead --json`,
+		`xcodecli tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'`,
+		`xcodecli tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'`,
 	}
 }
 
 func formatAgentDemo(report agentDemoReport) string {
 	var b strings.Builder
-	b.WriteString("xcodemcp agent demo\n\n")
+	b.WriteString("xcodecli agent demo\n\n")
 
 	b.WriteString("Environment\n")
 	b.WriteString("-----------\n")

--- a/cmd/xcodecli/agent_demo_test.go
+++ b/cmd/xcodecli/agent_demo_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/doctor"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 func TestParseCLIAgentDemo(t *testing.T) {
@@ -37,7 +37,7 @@ func TestParseCLIHelpAgentDemo(t *testing.T) {
 
 func TestRootUsageIncludesAgentDemo(t *testing.T) {
 	usage := rootUsage()
-	for _, want := range []string{"xcodemcp agent demo", "xcodemcp tools list", "xcodemcp tool call XcodeListWindows --json '{}'"} {
+	for _, want := range []string{"xcodecli agent demo", "xcodecli tools list", "xcodecli tool call XcodeListWindows --json '{}'"} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("root usage missing %q: %s", want, usage)
 		}
@@ -46,7 +46,7 @@ func TestRootUsageIncludesAgentDemo(t *testing.T) {
 
 func TestAgentUsageIncludesDemo(t *testing.T) {
 	usage := agentUsage()
-	for _, want := range []string{"xcodemcp agent demo", "demo         Run a safe read-only onboarding demo"} {
+	for _, want := range []string{"xcodecli agent demo", "demo         Run a safe read-only onboarding demo"} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("agent usage missing %q: %s", want, usage)
 		}
@@ -97,7 +97,7 @@ func TestRunAgentDemoText(t *testing.T) {
 			"XcodeListWindows",
 			"XcodeLS",
 			"XcodeRead",
-			"xcodemcp tool inspect XcodeRead --json",
+			"xcodecli tool inspect XcodeRead --json",
 			"* tabIdentifier: windowtab1, workspacePath: /tmp/Demo.xcodeproj",
 			"launchagent after tools discovery: running=true socketReachable=true backendSessions=2",
 		} {

--- a/cmd/xcodecli/agent_guide.go
+++ b/cmd/xcodecli/agent_guide.go
@@ -9,9 +9,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
-	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/doctor"
 )
 
 const guideWorkflowCatalog = "catalog"
@@ -138,7 +138,7 @@ type guideWindowMatch struct {
 func runAgentGuide(ctx context.Context, cfg cliConfig, env []string, stdout, stderr io.Writer, agentCfg agent.Config) int {
 	resolved, err := resolveEffectiveOptions(env, cfg)
 	if err != nil {
-		fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+		fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 		return 1
 	}
 	if cfg.Debug {
@@ -146,7 +146,7 @@ func runAgentGuide(ctx context.Context, cfg cliConfig, env []string, stdout, std
 	}
 	effective := resolved.EnvOptions
 	if err := bridge.ValidateEnvOptions(effective); err != nil {
-		fmt.Fprintf(stderr, "xcodemcp: invalid MCP options: %v\n", err)
+		fmt.Fprintf(stderr, "xcodecli: invalid MCP options: %v\n", err)
 		return 1
 	}
 
@@ -171,7 +171,7 @@ func runAgentGuide(ctx context.Context, cfg cliConfig, env []string, stdout, std
 
 	if cfg.JSONOutput {
 		if err := writeJSON(stdout, report); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		return 0
@@ -615,7 +615,7 @@ func buildGuideCatalogWorkflow() (guideWorkflowResult, []string) {
 
 	nextCommands := make([]string, 0, len(guideWorkflowOrder))
 	for _, workflowID := range guideWorkflowOrder {
-		nextCommands = append(nextCommands, fmt.Sprintf(`xcodemcp agent guide %s`, shellQuote(guideWorkflowExamples[workflowID])))
+		nextCommands = append(nextCommands, fmt.Sprintf(`xcodecli agent guide %s`, shellQuote(guideWorkflowExamples[workflowID])))
 	}
 
 	return guideWorkflowResult{
@@ -632,7 +632,7 @@ func buildGuideCatalogWorkflow() (guideWorkflowResult, []string) {
 			{
 				Title:       "If you want safe live context first",
 				Description: "Use agent demo to see the live window list and current tool catalog before picking a workflow.",
-				Commands:    []string{"xcodemcp agent demo"},
+				Commands:    []string{"xcodecli agent demo"},
 			},
 		},
 	}, nextCommands
@@ -666,7 +666,7 @@ func buildGuideBuildWorkflow(intent guideIntentMatch, tabIdentifier string, wind
 			Title:       "If the window match looks wrong",
 			Description: "Re-check the live Xcode windows and swap in the exact tabIdentifier yourself.",
 			Commands: []string{
-				`xcodemcp tool call XcodeListWindows --json '{}'`,
+				`xcodecli tool call XcodeListWindows --json '{}'`,
 				formatBuildProjectCommand("<tabIdentifier from above>"),
 			},
 		},
@@ -674,8 +674,8 @@ func buildGuideBuildWorkflow(intent guideIntentMatch, tabIdentifier string, wind
 			Title:       "If you want schema reassurance",
 			Description: "Inspect the tool schemas before executing the build flow.",
 			Commands: []string{
-				`xcodemcp tool inspect BuildProject --json`,
-				`xcodemcp tool inspect GetBuildLog --json`,
+				`xcodecli tool inspect BuildProject --json`,
+				`xcodecli tool inspect GetBuildLog --json`,
 			},
 		},
 	}
@@ -731,8 +731,8 @@ func buildGuideTestWorkflow(intent guideIntentMatch, tabIdentifier string, windo
 			Title:       "If schema details matter",
 			Description: "Inspect the testing tool schemas before composing a narrower payload.",
 			Commands: []string{
-				`xcodemcp tool inspect GetTestList --json`,
-				`xcodemcp tool inspect RunSomeTests --json`,
+				`xcodecli tool inspect GetTestList --json`,
+				`xcodecli tool inspect RunSomeTests --json`,
 			},
 		},
 	}
@@ -794,8 +794,8 @@ func buildGuideReadWorkflow(intent guideIntentMatch, tabIdentifier string, windo
 			Title:       "If you want schema reassurance",
 			Description: "Inspect the lookup and read schemas before composing a larger payload.",
 			Commands: []string{
-				fmt.Sprintf(`xcodemcp tool inspect %s --json`, lookupTool),
-				`xcodemcp tool inspect XcodeRead --json`,
+				fmt.Sprintf(`xcodecli tool inspect %s --json`, lookupTool),
+				`xcodecli tool inspect XcodeRead --json`,
 			},
 		},
 	}
@@ -841,8 +841,8 @@ func buildGuideSearchWorkflow(intent guideIntentMatch, tabIdentifier string, win
 			Title:       "If the first search is too broad",
 			Description: "Refine the glob, grep pattern, or output mode after you see the initial results.",
 			Commands: []string{
-				`xcodemcp tool inspect XcodeGrep --json`,
-				`xcodemcp tool inspect XcodeGlob --json`,
+				`xcodecli tool inspect XcodeGrep --json`,
+				`xcodecli tool inspect XcodeGlob --json`,
 			},
 		},
 	}
@@ -906,7 +906,7 @@ func buildGuideEditWorkflow(intent guideIntentMatch, tabIdentifier string, windo
 			Title:       "If the change is a full rewrite",
 			Description: "Switch from XcodeUpdate to XcodeWrite once you know the entire target file contents.",
 			Commands: []string{
-				`xcodemcp tool inspect XcodeWrite --json`,
+				`xcodecli tool inspect XcodeWrite --json`,
 				formatXcodeWriteTemplate(tabIdentifier, pathPlaceholder),
 			},
 		},
@@ -914,8 +914,8 @@ func buildGuideEditWorkflow(intent guideIntentMatch, tabIdentifier string, windo
 			Title:       "If you want schema reassurance",
 			Description: "Inspect the edit tool schemas before composing a large replacement payload.",
 			Commands: []string{
-				`xcodemcp tool inspect XcodeUpdate --json`,
-				`xcodemcp tool inspect XcodeRefreshCodeIssuesInFile --json`,
+				`xcodecli tool inspect XcodeUpdate --json`,
+				`xcodecli tool inspect XcodeRefreshCodeIssuesInFile --json`,
 			},
 		},
 	}
@@ -963,7 +963,7 @@ func buildGuideDiagnoseWorkflow(intent guideIntentMatch, tabIdentifier string, w
 			Title:       "If you need issue navigator context",
 			Description: "Inspect the issue navigator tool schema before composing a filtered request.",
 			Commands: []string{
-				`xcodemcp tool inspect XcodeListNavigatorIssues --json`,
+				`xcodecli tool inspect XcodeListNavigatorIssues --json`,
 			},
 		},
 		{
@@ -986,7 +986,7 @@ func buildGuideDiagnoseWorkflow(intent guideIntentMatch, tabIdentifier string, w
 
 func formatAgentGuide(report agentGuideReport, windowMatch guideWindowMatch) string {
 	var b strings.Builder
-	b.WriteString("xcodemcp agent guide\n\n")
+	b.WriteString("xcodecli agent guide\n\n")
 
 	b.WriteString("Intent\n")
 	b.WriteString("------\n")
@@ -1091,7 +1091,7 @@ func guideWindowSkipReason(windowMatch guideWindowMatch) string {
 func buildGuideBuildCommands(tabIdentifier string, windowMatch guideWindowMatch) []string {
 	commands := []string{}
 	if windowMatch.MatchedEntry == nil {
-		commands = append(commands, `xcodemcp tool call XcodeListWindows --json '{}'`)
+		commands = append(commands, `xcodecli tool call XcodeListWindows --json '{}'`)
 	}
 	commands = append(commands,
 		formatBuildProjectCommand(tabIdentifier),
@@ -1103,7 +1103,7 @@ func buildGuideBuildCommands(tabIdentifier string, windowMatch guideWindowMatch)
 func buildGuideTestCommands(tabIdentifier string, windowMatch guideWindowMatch) []string {
 	commands := []string{}
 	if windowMatch.MatchedEntry == nil {
-		commands = append(commands, `xcodemcp tool call XcodeListWindows --json '{}'`)
+		commands = append(commands, `xcodecli tool call XcodeListWindows --json '{}'`)
 	}
 	commands = append(commands,
 		formatRunAllTestsCommand(tabIdentifier),
@@ -1115,7 +1115,7 @@ func buildGuideTestCommands(tabIdentifier string, windowMatch guideWindowMatch) 
 func buildGuideReadCommands(tabIdentifier, subject string, windowMatch guideWindowMatch) []string {
 	commands := []string{}
 	if windowMatch.MatchedEntry == nil {
-		commands = append(commands, `xcodemcp tool call XcodeListWindows --json '{}'`)
+		commands = append(commands, `xcodecli tool call XcodeListWindows --json '{}'`)
 	}
 	if looksLikeFileHint(subject) {
 		commands = append(commands,
@@ -1134,7 +1134,7 @@ func buildGuideReadCommands(tabIdentifier, subject string, windowMatch guideWind
 func buildGuideSearchCommands(tabIdentifier, subject string, windowMatch guideWindowMatch) []string {
 	commands := []string{}
 	if windowMatch.MatchedEntry == nil {
-		commands = append(commands, `xcodemcp tool call XcodeListWindows --json '{}'`)
+		commands = append(commands, `xcodecli tool call XcodeListWindows --json '{}'`)
 	}
 	if looksLikeFileHint(subject) {
 		commands = append(commands, formatXcodeGlobCommand(tabIdentifier, guideGlobPattern(subject)))
@@ -1147,7 +1147,7 @@ func buildGuideSearchCommands(tabIdentifier, subject string, windowMatch guideWi
 func buildGuideEditCommands(tabIdentifier, subject string, windowMatch guideWindowMatch) []string {
 	commands := []string{}
 	if windowMatch.MatchedEntry == nil {
-		commands = append(commands, `xcodemcp tool call XcodeListWindows --json '{}'`)
+		commands = append(commands, `xcodecli tool call XcodeListWindows --json '{}'`)
 	}
 	pathPlaceholder := "<path from XcodeLS>"
 	if looksLikeFileHint(subject) {
@@ -1167,7 +1167,7 @@ func buildGuideEditCommands(tabIdentifier, subject string, windowMatch guideWind
 func buildGuideDiagnoseCommands(tabIdentifier string, windowMatch guideWindowMatch) []string {
 	commands := []string{}
 	if windowMatch.MatchedEntry == nil {
-		commands = append(commands, `xcodemcp tool call XcodeListWindows --json '{}'`)
+		commands = append(commands, `xcodecli tool call XcodeListWindows --json '{}'`)
 	}
 	commands = append(commands,
 		formatGetBuildLogCommand(tabIdentifier, "error"),
@@ -1232,58 +1232,58 @@ func guideSearchPattern(subject string) string {
 }
 
 func formatBuildProjectCommand(tabIdentifier string) string {
-	return fmt.Sprintf(`xcodemcp tool call BuildProject --timeout 300s --json '{"tabIdentifier":%s}'`, jsonQuote(tabIdentifier))
+	return fmt.Sprintf(`xcodecli tool call BuildProject --timeout 300s --json '{"tabIdentifier":%s}'`, jsonQuote(tabIdentifier))
 }
 
 func formatGetBuildLogCommand(tabIdentifier, severity string) string {
-	return fmt.Sprintf(`xcodemcp tool call GetBuildLog --timeout 60s --json '{"tabIdentifier":%s,"severity":%s}'`, jsonQuote(tabIdentifier), jsonQuote(severity))
+	return fmt.Sprintf(`xcodecli tool call GetBuildLog --timeout 60s --json '{"tabIdentifier":%s,"severity":%s}'`, jsonQuote(tabIdentifier), jsonQuote(severity))
 }
 
 func formatRunAllTestsCommand(tabIdentifier string) string {
-	return fmt.Sprintf(`xcodemcp tool call RunAllTests --timeout 300s --json '{"tabIdentifier":%s}'`, jsonQuote(tabIdentifier))
+	return fmt.Sprintf(`xcodecli tool call RunAllTests --timeout 300s --json '{"tabIdentifier":%s}'`, jsonQuote(tabIdentifier))
 }
 
 func formatGetTestListCommand(tabIdentifier string) string {
-	return fmt.Sprintf(`xcodemcp tool call GetTestList --timeout 60s --json '{"tabIdentifier":%s}'`, jsonQuote(tabIdentifier))
+	return fmt.Sprintf(`xcodecli tool call GetTestList --timeout 60s --json '{"tabIdentifier":%s}'`, jsonQuote(tabIdentifier))
 }
 
 func formatRunSomeTestsTemplate(tabIdentifier string) string {
-	return fmt.Sprintf(`xcodemcp tool call RunSomeTests --timeout 300s --json '{"tabIdentifier":%s,"tests":[{"targetName":"<targetName>","testIdentifier":"<identifier>"}]}'`, jsonQuote(tabIdentifier))
+	return fmt.Sprintf(`xcodecli tool call RunSomeTests --timeout 300s --json '{"tabIdentifier":%s,"tests":[{"targetName":"<targetName>","testIdentifier":"<identifier>"}]}'`, jsonQuote(tabIdentifier))
 }
 
 func formatXcodeLSCommand(tabIdentifier, path string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeLS --timeout 60s --json '{"tabIdentifier":%s,"path":%s}'`, jsonQuote(tabIdentifier), jsonQuote(path))
+	return fmt.Sprintf(`xcodecli tool call XcodeLS --timeout 60s --json '{"tabIdentifier":%s,"path":%s}'`, jsonQuote(tabIdentifier), jsonQuote(path))
 }
 
 func formatXcodeGlobCommand(tabIdentifier, pattern string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeGlob --timeout 60s --json '{"tabIdentifier":%s,"pattern":%s}'`, jsonQuote(tabIdentifier), jsonQuote(pattern))
+	return fmt.Sprintf(`xcodecli tool call XcodeGlob --timeout 60s --json '{"tabIdentifier":%s,"pattern":%s}'`, jsonQuote(tabIdentifier), jsonQuote(pattern))
 }
 
 func formatXcodeReadCommand(tabIdentifier, filePath string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeRead --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
+	return fmt.Sprintf(`xcodecli tool call XcodeRead --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
 }
 
 func formatXcodeGrepCommand(tabIdentifier, pattern string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeGrep --timeout 60s --json '{"tabIdentifier":%s,"pattern":%s,"outputMode":"content","showLineNumbers":true}'`, jsonQuote(tabIdentifier), jsonQuote(pattern))
+	return fmt.Sprintf(`xcodecli tool call XcodeGrep --timeout 60s --json '{"tabIdentifier":%s,"pattern":%s,"outputMode":"content","showLineNumbers":true}'`, jsonQuote(tabIdentifier), jsonQuote(pattern))
 }
 
 func formatXcodeUpdateTemplate(tabIdentifier, filePath string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeUpdate --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s,"oldString":"<exact text to replace>","newString":"<replacement text>"}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
+	return fmt.Sprintf(`xcodecli tool call XcodeUpdate --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s,"oldString":"<exact text to replace>","newString":"<replacement text>"}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
 }
 
 func formatRefreshIssuesCommand(tabIdentifier, filePath string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeRefreshCodeIssuesInFile --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
+	return fmt.Sprintf(`xcodecli tool call XcodeRefreshCodeIssuesInFile --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
 }
 
 func formatXcodeWriteTemplate(tabIdentifier, filePath string) string {
-	return fmt.Sprintf(`xcodemcp tool call XcodeWrite --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s,"content":"<full file contents>"}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
+	return fmt.Sprintf(`xcodecli tool call XcodeWrite --timeout 60s --json '{"tabIdentifier":%s,"filePath":%s,"content":"<full file contents>"}'`, jsonQuote(tabIdentifier), jsonQuote(filePath))
 }
 
 func formatMaybeWindowsCommand(windowMatch guideWindowMatch) string {
 	if windowMatch.MatchedEntry != nil {
 		return fmt.Sprintf("# already matched %s", windowMatch.MatchedEntry.TabIdentifier)
 	}
-	return `xcodemcp tool call XcodeListWindows --json '{}'`
+	return `xcodecli tool call XcodeListWindows --json '{}'`
 }
 
 func jsonQuote(value string) string {

--- a/cmd/xcodecli/agent_guide_test.go
+++ b/cmd/xcodecli/agent_guide_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/doctor"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 func TestParseCLIAgentGuide(t *testing.T) {
@@ -40,7 +40,7 @@ func TestRootAndAgentUsageIncludeGuide(t *testing.T) {
 		usage string
 		want  []string
 	}{
-		{"root", rootUsage(), []string{"xcodemcp agent guide", "xcodemcp agent demo"}},
+		{"root", rootUsage(), []string{"xcodecli agent guide", "xcodecli agent demo"}},
 		{"agent", agentUsage(), []string{"guide        Explain the recommended tool workflow for a request", "demo         Run a safe read-only onboarding demo"}},
 	} {
 		for _, want := range tc.want {

--- a/cmd/xcodecli/cli.go
+++ b/cmd/xcodecli/cli.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/agent"
 )
 
 type commandName string
@@ -53,11 +53,11 @@ func parseCLI(args []string) (cliConfig, string, error) {
 	case "help", "-h", "--help":
 		return parseHelp(args[1:])
 	case string(commandBridge):
-		cfg, err := parseBridgeFlags("xcodemcp bridge", args[1:])
+		cfg, err := parseBridgeFlags("xcodecli bridge", args[1:])
 		cfg.Command = commandBridge
 		return cfg, bridgeUsage(), err
 	case string(commandDoctor):
-		cfg, err := parseDoctorFlags("xcodemcp doctor", args[1:])
+		cfg, err := parseDoctorFlags("xcodecli doctor", args[1:])
 		cfg.Command = commandDoctor
 		return cfg, doctorUsage(), err
 	case "tools":
@@ -68,7 +68,7 @@ func parseCLI(args []string) (cliConfig, string, error) {
 		return parseAgentCLI(args[1:])
 	default:
 		if strings.HasPrefix(args[0], "-") {
-			cfg, err := parseBridgeFlags("xcodemcp", args)
+			cfg, err := parseBridgeFlags("xcodecli", args)
 			cfg.Command = commandBridge
 			return cfg, bridgeUsage(), err
 		}
@@ -134,7 +134,7 @@ func parseToolsCLI(args []string) (cliConfig, string, error) {
 	}
 	switch args[0] {
 	case "list":
-		cfg, err := parseToolsListFlags("xcodemcp tools list", args[1:])
+		cfg, err := parseToolsListFlags("xcodecli tools list", args[1:])
 		cfg.Command = commandToolsList
 		return cfg, toolsListUsage(), err
 	default:
@@ -148,11 +148,11 @@ func parseToolCLI(args []string) (cliConfig, string, error) {
 	}
 	switch args[0] {
 	case "call":
-		cfg, err := parseToolCallFlags("xcodemcp tool call", args[1:])
+		cfg, err := parseToolCallFlags("xcodecli tool call", args[1:])
 		cfg.Command = commandToolCall
 		return cfg, toolCallUsage(), err
 	case "inspect":
-		cfg, err := parseToolInspectFlags("xcodemcp tool inspect", args[1:])
+		cfg, err := parseToolInspectFlags("xcodecli tool inspect", args[1:])
 		cfg.Command = commandToolInspect
 		return cfg, toolInspectUsage(), err
 	default:
@@ -166,27 +166,27 @@ func parseAgentCLI(args []string) (cliConfig, string, error) {
 	}
 	switch args[0] {
 	case "guide":
-		cfg, err := parseAgentGuideFlags("xcodemcp agent guide", args[1:])
+		cfg, err := parseAgentGuideFlags("xcodecli agent guide", args[1:])
 		cfg.Command = commandAgentGuide
 		return cfg, agentGuideUsage(), err
 	case "demo":
-		cfg, err := parseAgentDemoFlags("xcodemcp agent demo", args[1:])
+		cfg, err := parseAgentDemoFlags("xcodecli agent demo", args[1:])
 		cfg.Command = commandAgentDemo
 		return cfg, agentDemoUsage(), err
 	case "status":
-		cfg, err := parseAgentStatusFlags("xcodemcp agent status", args[1:])
+		cfg, err := parseAgentStatusFlags("xcodecli agent status", args[1:])
 		cfg.Command = commandAgentStatus
 		return cfg, agentStatusUsage(), err
 	case "stop":
-		cfg, err := parseAgentSimpleFlags("xcodemcp agent stop", args[1:])
+		cfg, err := parseAgentSimpleFlags("xcodecli agent stop", args[1:])
 		cfg.Command = commandAgentStop
 		return cfg, agentStopUsage(), err
 	case "uninstall":
-		cfg, err := parseAgentSimpleFlags("xcodemcp agent uninstall", args[1:])
+		cfg, err := parseAgentSimpleFlags("xcodecli agent uninstall", args[1:])
 		cfg.Command = commandAgentUninstall
 		return cfg, agentUninstallUsage(), err
 	case "run":
-		cfg, err := parseAgentRunFlags("xcodemcp agent run", args[1:])
+		cfg, err := parseAgentRunFlags("xcodecli agent run", args[1:])
 		cfg.Command = commandAgentRun
 		return cfg, agentRunUsage(), err
 	default:
@@ -526,24 +526,24 @@ func newFlagSet(name string) *flag.FlagSet {
 }
 
 func rootUsage() string {
-	return `xcodemcp wraps xcrun mcpbridge for local macOS use.
+	return `xcodecli wraps xcrun mcpbridge for local macOS use.
 
 START HERE:
   For humans:
-    1. xcodemcp agent guide "build Unicody"
-    2. xcodemcp agent demo
-    3. xcodemcp doctor --json
-    4. xcodemcp tools list
-    5. xcodemcp tool call XcodeListWindows --json '{}'
+    1. xcodecli agent guide "build Unicody"
+    2. xcodecli agent demo
+    3. xcodecli doctor --json
+    4. xcodecli tools list
+    5. xcodecli tool call XcodeListWindows --json '{}'
 
   For agents:
-    - Start with a workflow tutor via "xcodemcp agent guide <intent> --json".
-    - Run a safe live onboarding demo with "xcodemcp agent demo --json".
-    - Discover command shapes with "xcodemcp help <command>".
-    - Discover runtime health with "xcodemcp doctor --json".
-    - Discover LaunchAgent state with "xcodemcp agent status --json".
-    - Discover available tools with "xcodemcp tools list --json".
-    - Discover per-tool schema with "xcodemcp tool inspect <name> --json".
+    - Start with a workflow tutor via "xcodecli agent guide <intent> --json".
+    - Run a safe live onboarding demo with "xcodecli agent demo --json".
+    - Discover command shapes with "xcodecli help <command>".
+    - Discover runtime health with "xcodecli doctor --json".
+    - Discover LaunchAgent state with "xcodecli agent status --json".
+    - Discover available tools with "xcodecli tools list --json".
+    - Discover per-tool schema with "xcodecli tool inspect <name> --json".
 
 RUNTIME MODEL:
   - "bridge" is raw passthrough to xcrun mcpbridge.
@@ -552,17 +552,17 @@ RUNTIME MODEL:
   - Xcode should be running, with at least one workspace/project window open.
 
 USAGE:
-  xcodemcp [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp bridge [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp doctor [--json] [--xcode-pid PID] [--session-id UUID]
-  xcodemcp tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp agent guide [<intent>] [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp agent status [--json]
-  xcodemcp agent stop
-  xcodemcp agent uninstall
+  xcodecli [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli bridge [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli doctor [--json] [--xcode-pid PID] [--session-id UUID]
+  xcodecli tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent guide [<intent>] [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent status [--json]
+  xcodecli agent stop
+  xcodecli agent uninstall
 
 COMMANDS:
   bridge    Run raw STDIO passthrough to xcrun mcpbridge
@@ -571,7 +571,7 @@ COMMANDS:
   tool      Convenience commands for inspecting or calling a tool
   agent     Inspect or manage the LaunchAgent used by tools commands
 
-Use "xcodemcp help <command>" for command-specific help.
+Use "xcodecli help <command>" for command-specific help.
 `
 }
 
@@ -580,8 +580,8 @@ func bridgeUsage() string {
 Use this when you already have an MCP-aware client and need raw transport.
 
 USAGE:
-  xcodemcp [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp bridge [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli bridge [--xcode-pid PID] [--session-id UUID] [--debug]
 
 FLAGS:
   --xcode-pid PID     Override MCP_XCODE_PID
@@ -596,7 +596,7 @@ func doctorUsage() string {
 Prefer --json when another tool or agent needs to parse the result.
 
 USAGE:
-  xcodemcp doctor [--json] [--xcode-pid PID] [--session-id UUID]
+  xcodecli doctor [--json] [--xcode-pid PID] [--session-id UUID]
 
 FLAGS:
   --json              Print the diagnostic report as pretty JSON
@@ -611,7 +611,7 @@ func toolsUsage() string {
 Inspect a tool before calling it if you need its schema or description.
 
 USAGE:
-  xcodemcp tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 SUBCOMMANDS:
   list      List MCP tools exposed through xcrun mcpbridge via the LaunchAgent
@@ -623,7 +623,7 @@ func toolsListUsage() string {
 This is the primary entrypoint for both humans and agents to learn what is available.
 
 USAGE:
-  xcodemcp tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tools list [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 FLAGS:
   --json               Print the flattened tools array as pretty JSON
@@ -643,8 +643,8 @@ func toolUsage() string {
 Agents should usually inspect before calling unless they already cached the schema.
 
 USAGE:
-  xcodemcp tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 SUBCOMMANDS:
   inspect   Show tool description and input schema
@@ -657,7 +657,7 @@ func toolInspectUsage() string {
 Use --json for machine-readable metadata or plain text for quick inspection.
 
 USAGE:
-  xcodemcp tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tool inspect <name> [--json] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 FLAGS:
   --json               Print the raw tool object as pretty JSON
@@ -673,7 +673,7 @@ func toolCallUsage() string {
 For large payloads prefer --json @file or --json-stdin instead of a long inline string.
 
 USAGE:
-  xcodemcp tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli tool call <name> (--json '{...}' | --json @payload.json | --json-stdin) [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 FLAGS:
   --json PAYLOAD       JSON object passed as tools/call arguments, or @path to load a JSON file
@@ -694,11 +694,11 @@ func agentUsage() string {
 Use guide to learn the right workflow for a request, demo for a safe read-only onboarding flow, status for diagnostics, stop to end the running process, and uninstall to remove local LaunchAgent state.
 
 USAGE:
-  xcodemcp agent guide [<intent>] [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
-  xcodemcp agent status [--json]
-  xcodemcp agent stop
-  xcodemcp agent uninstall
+  xcodecli agent guide [<intent>] [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent status [--json]
+  xcodecli agent stop
+  xcodecli agent uninstall
 
 SUBCOMMANDS:
   guide        Explain the recommended tool workflow for a request
@@ -710,11 +710,11 @@ SUBCOMMANDS:
 }
 
 func agentGuideUsage() string {
-	return `agent guide explains the recommended xcodemcp workflow for a request without executing mutating tools.
+	return `agent guide explains the recommended xcodecli workflow for a request without executing mutating tools.
 It gathers lightweight live context, matches your intent to a workflow family, and prints exact next commands.
 
 USAGE:
-  xcodemcp agent guide [<intent>] [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent guide [<intent>] [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 FLAGS:
   --json               Print the full guide report as pretty JSON
@@ -734,7 +734,7 @@ func agentDemoUsage() string {
 It reuses doctor output, discovers the live MCP tool catalog, and safely calls XcodeListWindows.
 
 USAGE:
-  xcodemcp agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
+  xcodecli agent demo [--json] [--timeout 30s] [--xcode-pid PID] [--session-id UUID] [--debug]
 
 FLAGS:
   --json               Print the full demo report as pretty JSON
@@ -754,7 +754,7 @@ func agentStatusUsage() string {
 Prefer --json when another agent or script needs to consume the result.
 
 USAGE:
-  xcodemcp agent status [--json]
+  xcodecli agent status [--json]
 `
 }
 
@@ -762,7 +762,7 @@ func agentStopUsage() string {
 	return `agent stop asks the running LaunchAgent process to exit if it is currently alive.
 
 USAGE:
-  xcodemcp agent stop
+  xcodecli agent stop
 `
 }
 
@@ -771,7 +771,7 @@ func agentUninstallUsage() string {
 Use this if the LaunchAgent is stale or you want to reset local state.
 
 USAGE:
-  xcodemcp agent uninstall
+  xcodecli agent uninstall
 `
 }
 
@@ -780,7 +780,7 @@ func agentRunUsage() string {
 Most users and agents should not call it directly.
 
 USAGE:
-  xcodemcp agent run --launch-agent [--idle-timeout 10m] [--debug]
+  xcodecli agent run --launch-agent [--idle-timeout 10m] [--debug]
 
 FLAGS:
   --launch-agent       Required internal flag used by the LaunchAgent plist

--- a/cmd/xcodecli/main.go
+++ b/cmd/xcodecli/main.go
@@ -13,10 +13,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
-	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/doctor"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 var defaultBridgeCommand = bridge.Command{Path: "xcrun", Args: []string{"mcpbridge"}}
@@ -46,7 +46,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 			fmt.Fprint(stdout, usage)
 			return 0
 		}
-		fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+		fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 		if usage != "" {
 			fmt.Fprint(stderr, usage)
 		}
@@ -54,13 +54,13 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	}
 
 	if runtime.GOOS != "darwin" {
-		fmt.Fprintln(stderr, "xcodemcp: only macOS (darwin) is supported")
+		fmt.Fprintln(stderr, "xcodecli: only macOS (darwin) is supported")
 		return 1
 	}
 
 	agentCfg, err := defaultAgentConfigFunc(defaultMCPCommand, env, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+		fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 		return 1
 	}
 	if cfg.IdleTimeout > 0 {
@@ -71,7 +71,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	case commandDoctor:
 		resolved, err := resolveEffectiveOptions(env, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		agentStatus, agentStatusErr := defaultAgentStatusFunc(ctx, agentCfg)
@@ -86,7 +86,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		})
 		if cfg.JSONOutput {
 			if err := writeJSON(stdout, report.JSON()); err != nil {
-				fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+				fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 				return 1
 			}
 		} else {
@@ -99,7 +99,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	case commandBridge:
 		resolved, err := resolveEffectiveOptions(env, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if cfg.Debug {
@@ -107,7 +107,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		}
 		effective := resolved.EnvOptions
 		if err := bridge.ValidateEnvOptions(effective); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: invalid bridge options: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: invalid bridge options: %v\n", err)
 			return 1
 		}
 
@@ -120,14 +120,14 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 			Debug:   cfg.Debug,
 		})
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		return result.ExitCode
 	case commandToolsList:
 		resolved, err := resolveEffectiveOptions(env, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if cfg.Debug {
@@ -135,7 +135,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		}
 		effective := resolved.EnvOptions
 		if err := bridge.ValidateEnvOptions(effective); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: invalid MCP options: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: invalid MCP options: %v\n", err)
 			return 1
 		}
 		requestCtx, cancel := requestTimeoutContext(ctx, cfg.Timeout)
@@ -143,12 +143,12 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		request := agentRequest(env, effective, cfg)
 		tools, err := defaultToolsListFunc(requestCtx, agentCfg, request)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if cfg.JSONOutput {
 			if err := writeJSON(stdout, tools); err != nil {
-				fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+				fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 				return 1
 			}
 			return 0
@@ -166,7 +166,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	case commandToolInspect:
 		resolved, err := resolveEffectiveOptions(env, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if cfg.Debug {
@@ -174,7 +174,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		}
 		effective := resolved.EnvOptions
 		if err := bridge.ValidateEnvOptions(effective); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: invalid MCP options: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: invalid MCP options: %v\n", err)
 			return 1
 		}
 		requestCtx, cancel := requestTimeoutContext(ctx, cfg.Timeout)
@@ -182,30 +182,30 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		request := agentRequest(env, effective, cfg)
 		tools, err := defaultToolsListFunc(requestCtx, agentCfg, request)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		tool, found := findToolByName(tools, cfg.ToolName)
 		if !found {
-			fmt.Fprintf(stderr, "xcodemcp: tool not found: %s\n", cfg.ToolName)
+			fmt.Fprintf(stderr, "xcodecli: tool not found: %s\n", cfg.ToolName)
 			return 1
 		}
 		if cfg.JSONOutput {
 			if err := writeJSON(stdout, tool); err != nil {
-				fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+				fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 				return 1
 			}
 			return 0
 		}
 		if err := writeToolInspect(stdout, tool); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		return 0
 	case commandToolCall:
 		resolved, err := resolveEffectiveOptions(env, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if cfg.Debug {
@@ -213,12 +213,12 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		}
 		effective := resolved.EnvOptions
 		if err := bridge.ValidateEnvOptions(effective); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: invalid MCP options: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: invalid MCP options: %v\n", err)
 			return 1
 		}
 		arguments, err := resolveToolArguments(stdin, cfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		requestCtx, cancel := requestTimeoutContext(ctx, cfg.Timeout)
@@ -226,11 +226,11 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		request := agentRequest(env, effective, cfg)
 		result, err := defaultToolCallFunc(requestCtx, agentCfg, request, cfg.ToolName, arguments)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if err := writeJSON(stdout, result.Result); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if result.IsError {
@@ -244,12 +244,12 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	case commandAgentStatus:
 		status, err := defaultAgentStatusFunc(ctx, agentCfg)
 		if err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		if cfg.JSONOutput {
 			if err := writeJSON(stdout, status); err != nil {
-				fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+				fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 				return 1
 			}
 		} else {
@@ -258,28 +258,28 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		return 0
 	case commandAgentStop:
 		if err := defaultAgentStopFunc(ctx, agentCfg); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		fmt.Fprintln(stdout, "stopped LaunchAgent process if it was running")
 		return 0
 	case commandAgentUninstall:
 		if err := defaultAgentUninstallFunc(ctx, agentCfg); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
-		fmt.Fprintln(stdout, "removed LaunchAgent plist and local agent runtime files")
+		fmt.Fprintln(stdout, "removed xcodecli LaunchAgent/runtime files and any legacy xcodemcp artifacts")
 		return 0
 	case commandAgentRun:
 		signalCtx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 		defer cancel()
 		if err := defaultAgentRunFunc(signalCtx, agentCfg); err != nil {
-			fmt.Fprintf(stderr, "xcodemcp: %v\n", err)
+			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
 		return 0
 	default:
-		fmt.Fprintf(stderr, "xcodemcp: unsupported command %q\n", cfg.Command)
+		fmt.Fprintf(stderr, "xcodecli: unsupported command %q\n", cfg.Command)
 		return 1
 	}
 }
@@ -366,6 +366,8 @@ func logResolvedSession(w io.Writer, resolved bridge.ResolvedOptions) {
 		fmt.Fprintf(w, "[debug] using persisted MCP_XCODE_SESSION_ID %s from %s\n", resolved.SessionID, resolved.SessionPath)
 	case bridge.SessionSourceGenerated:
 		fmt.Fprintf(w, "[debug] generated persistent MCP_XCODE_SESSION_ID %s at %s\n", resolved.SessionID, resolved.SessionPath)
+	case bridge.SessionSourceMigrated:
+		fmt.Fprintf(w, "[debug] migrated persistent MCP_XCODE_SESSION_ID %s into %s from legacy xcodemcp storage\n", resolved.SessionID, resolved.SessionPath)
 	}
 }
 
@@ -390,7 +392,7 @@ func formatAgentStatus(status agent.Status) string {
 	if status.SocketReachable {
 		socketText = "yes"
 	}
-	return fmt.Sprintf("xcodemcp agent\n\nlabel: %s\nplist installed: %t\nplist path: %s\nregistered binary: %s\ncurrent binary: %s\nbinary matches: %s\nsocket path: %s\nsocket reachable: %s\nrunning: %s\npid: %d\nidle timeout: %s\nbackend sessions: %d\n",
+	return fmt.Sprintf("xcodecli agent\n\nlabel: %s\nplist installed: %t\nplist path: %s\nregistered binary: %s\ncurrent binary: %s\nbinary matches: %s\nsocket path: %s\nsocket reachable: %s\nrunning: %s\npid: %d\nidle timeout: %s\nbackend sessions: %d\nlegacy label: %s\nlegacy plist installed: %t\nlegacy plist path: %s\nlegacy support dir: %s (exists=%t)\nlegacy session path: %s (exists=%t)\nlegacy socket path: %s (exists=%t)\n",
 		status.Label,
 		status.PlistInstalled,
 		status.PlistPath,
@@ -403,6 +405,15 @@ func formatAgentStatus(status agent.Status) string {
 		status.PID,
 		status.IdleTimeout,
 		status.BackendSessions,
+		status.Legacy.Label,
+		status.Legacy.PlistInstalled,
+		status.Legacy.PlistPath,
+		status.Legacy.SupportDir,
+		status.Legacy.SupportDirExists,
+		status.Legacy.SessionPath,
+		status.Legacy.SessionFileExists,
+		status.Legacy.SocketPath,
+		status.Legacy.SocketExists,
 	)
 }
 

--- a/cmd/xcodecli/main_test.go
+++ b/cmd/xcodecli/main_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
-	"github.com/oozoofrog/xcodemcp-cli/internal/doctor"
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/doctor"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 func TestParseCLIDefaultBridge(t *testing.T) {
@@ -28,7 +28,7 @@ func TestParseCLIDefaultBridge(t *testing.T) {
 	if cfg.XcodePID != "123" || cfg.SessionID != "11111111-1111-1111-1111-111111111111" || !cfg.Debug {
 		t.Fatalf("unexpected config: %+v", cfg)
 	}
-	if !strings.Contains(usage, "xcodemcp bridge") {
+	if !strings.Contains(usage, "xcodecli bridge") {
 		t.Fatalf("usage missing bridge help: %q", usage)
 	}
 }
@@ -131,7 +131,7 @@ func TestParseCLIHelp(t *testing.T) {
 
 func TestRootUsageIncludesHumanAndAgentGuidance(t *testing.T) {
 	usage := rootUsage()
-	for _, want := range []string{"START HERE:", "For humans:", "For agents:", "xcodemcp agent guide", "xcodemcp agent demo", "xcodemcp doctor --json", "xcodemcp tool inspect <name> --json"} {
+	for _, want := range []string{"START HERE:", "For humans:", "For agents:", "xcodecli agent guide", "xcodecli agent demo", "xcodecli doctor --json", "xcodecli tool inspect <name> --json"} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("root usage missing %q: %s", want, usage)
 		}
@@ -497,9 +497,9 @@ func TestRunAgentStatusText(t *testing.T) {
 			return agent.Status{
 				Label:             agent.LaunchAgentLabel,
 				PlistInstalled:    true,
-				PlistPath:         "/tmp/io.oozoofrog.xcodemcp.plist",
-				RegisteredBinary:  "/tmp/xcodemcp",
-				CurrentBinary:     "/tmp/xcodemcp",
+				PlistPath:         "/tmp/io.oozoofrog.xcodecli.plist",
+				RegisteredBinary:  "/tmp/xcodecli",
+				CurrentBinary:     "/tmp/xcodecli",
 				BinaryPathMatches: true,
 				SocketPath:        "/tmp/daemon.sock",
 				SocketReachable:   true,

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -1,11 +1,11 @@
-# xcodemcp agent quickstart
+# xcodecli agent quickstart
 
-This guide is for a first-time agent or automation that needs to discover and call Xcode MCP tools through `xcodemcp`.
+This guide is for a first-time agent or automation that needs to discover and call Xcode MCP tools through `xcodecli`.
 
 ## 1. Build the CLI
 
 ```bash
-cd /Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli
+cd /path/to/xcodecli
 ./scripts/build.sh
 ```
 
@@ -14,13 +14,13 @@ cd /Volumes/eyedisk/develop/oozoofrog/xcodemcp-cli
 If you already know the request, start with `agent guide`:
 
 ```bash
-./xcodemcp agent guide "build Unicody"
-./xcodemcp agent guide "run tests for Unicody"
-./xcodemcp agent guide "read KeyboardState.swift"
-./xcodemcp agent guide "search for AdManager"
-./xcodemcp agent guide "update KeyboardState.swift"
-./xcodemcp agent guide "diagnose build errors"
-./xcodemcp agent guide --json
+./xcodecli agent guide "build Unicody"
+./xcodecli agent guide "run tests for Unicody"
+./xcodecli agent guide "read KeyboardState.swift"
+./xcodecli agent guide "search for AdManager"
+./xcodecli agent guide "update KeyboardState.swift"
+./xcodecli agent guide "diagnose build errors"
+./xcodecli agent guide --json
 ```
 
 What this does:
@@ -32,8 +32,8 @@ What this does:
 ## 3. Fastest safe live demo
 
 ```bash
-./xcodemcp agent demo
-./xcodemcp agent demo --json
+./xcodecli agent demo
+./xcodecli agent demo --json
 ```
 
 What this does:
@@ -47,8 +47,8 @@ What this does:
 ## 4. Check the environment
 
 ```bash
-./xcodemcp doctor --json
-./xcodemcp agent status --json
+./xcodecli doctor --json
+./xcodecli agent status --json
 ```
 
 Look for:
@@ -59,17 +59,17 @@ Look for:
 ## 5. Discover available tools
 
 ```bash
-./xcodemcp tools list
-./xcodemcp tools list --json
+./xcodecli tools list
+./xcodecli tools list --json
 ```
 
-If this is the first `tools` request, `xcodemcp` may install and bootstrap a per-user LaunchAgent automatically.
+If this is the first `tools` request, `xcodecli` may install and bootstrap a per-user LaunchAgent automatically.
 
 ## 6. Inspect one tool
 
 ```bash
-./xcodemcp tool inspect XcodeListWindows
-./xcodemcp tool inspect XcodeListWindows --json
+./xcodecli tool inspect XcodeListWindows
+./xcodecli tool inspect XcodeListWindows --json
 ```
 
 Use `tool inspect` when you need schema reassurance. For the common workflows above, `agent guide` should usually tell you what to call without making this the first step.
@@ -79,7 +79,7 @@ Use `tool inspect` when you need schema reassurance. For the common workflows ab
 Inline JSON:
 
 ```bash
-./xcodemcp tool call XcodeListWindows --json '{}'
+./xcodecli tool call XcodeListWindows --json '{}'
 ```
 
 Read the payload from a file:
@@ -88,13 +88,13 @@ Read the payload from a file:
 cat > /tmp/payload.json <<'JSON'
 {"scheme":"Demo"}
 JSON
-./xcodemcp tool call BuildProject --json @/tmp/payload.json
+./xcodecli tool call BuildProject --json @/tmp/payload.json
 ```
 
 Read the payload from stdin:
 
 ```bash
-printf '{}' | ./xcodemcp tool call XcodeListWindows --json-stdin
+printf '{}' | ./xcodecli tool call XcodeListWindows --json-stdin
 ```
 
 ## 8. End-to-end read-only example
@@ -102,9 +102,9 @@ printf '{}' | ./xcodemcp tool call XcodeListWindows --json-stdin
 Use the `tabIdentifier` returned by `XcodeListWindows` to continue the flow:
 
 ```bash
-./xcodemcp tool call XcodeListWindows --json '{}'
-./xcodemcp tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'
-./xcodemcp tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'
+./xcodecli tool call XcodeListWindows --json '{}'
+./xcodecli tool call XcodeLS --json '{"tabIdentifier":"<tabIdentifier from above>","path":""}'
+./xcodecli tool call XcodeRead --json '{"tabIdentifier":"<tabIdentifier from above>","filePath":"<path from XcodeLS>"}'
 ```
 
 If you want the next mutating step after discovery, that is where you would choose something like `BuildProject` or `RunAllTests`.
@@ -114,16 +114,20 @@ If you want the next mutating step after discovery, that is where you would choo
 ### The tool call times out
 - Verify Xcode is open and a workspace/project window is visible.
 - Retry with `--debug`.
-- Re-run `./xcodemcp doctor --json`.
+- Re-run `./xcodecli doctor --json`.
 
 ### The LaunchAgent looks stale
 ```bash
-./xcodemcp agent status --json
-./xcodemcp agent stop
-./xcodemcp agent uninstall
+./xcodecli agent status --json
+./xcodecli agent stop
+./xcodecli agent uninstall
 ```
 
 Then retry `tools list` or `tool inspect`.
+
+### Legacy rename cleanup
+- If you previously used `xcodemcp`, run `./xcodecli agent uninstall` once to remove old LaunchAgent/runtime artifacts.
+- `./xcodecli doctor --json` and `./xcodecli agent status --json` will tell you whether any legacy `xcodemcp` files still exist.
 
 ### The payload is large or reused often
 Prefer `--json @file` over a huge inline string.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,4 +1,4 @@
-# Releasing xcodemcp
+# Releasing xcodecli
 
 ## Standard release flow
 
@@ -6,25 +6,26 @@
 2. Run the test/build checks locally:
    - `go test ./...`
    - `./scripts/build.sh`
-3. Create and push an annotated tag like `v0.2.1`.
+3. Create and push an annotated tag like `v0.3.0`.
 4. Publish the GitHub Release for that tag.
 5. The Homebrew release workflow updates the shared `oozoofrog/homebrew-tap` repository automatically.
 
 ## Homebrew automation
 
-`xcodemcp` is distributed through the shared `oozoofrog/homebrew-tap` repository:
+`xcodecli` is distributed through the shared `oozoofrog/homebrew-tap` repository:
 
 ```bash
 brew tap oozoofrog/tap
-brew install oozoofrog/tap/xcodemcp
+brew install oozoofrog/tap/xcodecli
 ```
 
 The automation path is:
 
-- GitHub Release published in `oozoofrog/xcodemcp-cli`
+- GitHub Release published in `oozoofrog/xcodecli`
 - `.github/workflows/homebrew-release.yml` runs
-- `scripts/release_homebrew.sh <tag> --push` updates the tap formula
-- `oozoofrog/homebrew-tap/Formula/xcodemcp.rb` is committed and pushed
+- `scripts/release_homebrew.sh <tag> --push` updates the tap formula and removes the legacy `xcodemcp` formula during cutover
+- `oozoofrog/homebrew-tap/Formula/xcodecli.rb` is committed and pushed
+- `oozoofrog/homebrew-tap/Formula/xcodemcp.rb` is removed
 - other formulas/casks in the shared tap are left untouched
 
 ## Manual recovery / local dry-run
@@ -32,24 +33,24 @@ The automation path is:
 Use this if the release workflow fails or before publishing a new version:
 
 ```bash
-./scripts/release_homebrew.sh v0.2.0 --tap-dir .tmp/homebrew-tap --dry-run
+./scripts/release_homebrew.sh v0.3.0 --tap-dir .tmp/homebrew-tap --dry-run
 ```
 
 To commit locally in the tap repo without pushing:
 
 ```bash
-./scripts/release_homebrew.sh v0.2.0 --tap-dir .tmp/homebrew-tap
+./scripts/release_homebrew.sh v0.3.0 --tap-dir .tmp/homebrew-tap
 ```
 
 To clone the tap automatically and push the update:
 
 ```bash
-HOMEBREW_TAP_GITHUB_TOKEN=... ./scripts/release_homebrew.sh v0.2.0 --push
+HOMEBREW_TAP_GITHUB_TOKEN=... ./scripts/release_homebrew.sh v0.3.0 --push
 ```
 
 ## Required GitHub secret
 
-Add this repository secret in `oozoofrog/xcodemcp-cli`:
+Add this repository secret in `oozoofrog/xcodecli`:
 
 - `HOMEBREW_TAP_GITHUB_TOKEN`
 
@@ -58,7 +59,7 @@ The token must be able to push to `oozoofrog/homebrew-tap`.
 ## Shared tap safety rules
 
 - Treat `oozoofrog/homebrew-tap` as a shared repository for multiple projects.
-- Only `Formula/xcodemcp.rb` should be created or updated by the `xcodemcp` release flow.
-- Validation temporarily backs up and restores only `Formula/xcodemcp.rb` inside the local Homebrew tap checkout.
-- If the tap clone has unrelated local changes, the release script should stop instead of mixing `xcodemcp` changes with other tap edits.
-- If validation or push fails, recover by re-running `./scripts/release_homebrew.sh <tag> --tap-dir <tap clone> --dry-run` and checking only the `Formula/xcodemcp.rb` diff.
+- Only `Formula/xcodecli.rb` should be created or updated, and `Formula/xcodemcp.rb` may be removed, by the `xcodecli` release flow.
+- Validation temporarily backs up and restores only `Formula/xcodecli.rb` inside the local Homebrew tap checkout.
+- If the tap clone has unrelated local changes, the release script should stop instead of mixing `xcodecli` changes with other tap edits.
+- If validation or push fails, recover by re-running `./scripts/release_homebrew.sh <tag> --tap-dir <tap clone> --dry-run` and checking the `Formula/xcodecli.rb` add/update plus any `Formula/xcodemcp.rb` removal.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/oozoofrog/xcodemcp-cli
+module github.com/oozoofrog/xcodecli
 
 go 1.26

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 type Config struct {
@@ -48,6 +48,19 @@ type Status struct {
 	PID               int           `json:"pid"`
 	IdleTimeout       time.Duration `json:"idleTimeout"`
 	BackendSessions   int           `json:"backendSessions"`
+	Legacy            LegacyStatus  `json:"legacy"`
+}
+
+type LegacyStatus struct {
+	Label             string `json:"label"`
+	PlistPath         string `json:"plistPath"`
+	PlistInstalled    bool   `json:"plistInstalled"`
+	SupportDir        string `json:"supportDir"`
+	SupportDirExists  bool   `json:"supportDirExists"`
+	SessionPath       string `json:"sessionPath"`
+	SessionFileExists bool   `json:"sessionFileExists"`
+	SocketPath        string `json:"socketPath"`
+	SocketExists      bool   `json:"socketExists"`
 }
 
 type runtimeStatus struct {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -15,7 +15,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 func TestListToolsAutoInstallsLaunchAgentAndReusesBackendSession(t *testing.T) {
@@ -92,7 +93,7 @@ func TestListToolsAutostartHonorsCallerTimeout(t *testing.T) {
 		IdleTimeout:    5 * time.Second,
 		ErrOut:         io.Discard,
 		Launchd:        blockingLaunchd{},
-		ExecutablePath: func() (string, error) { return "/tmp/xcodemcp-test", nil },
+		ExecutablePath: func() (string, error) { return "/tmp/xcodecli-test", nil },
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
@@ -151,6 +152,94 @@ func TestUninstallRemovesLaunchAgentArtifacts(t *testing.T) {
 	}
 }
 
+func TestStatusInfoIncludesLegacyArtifacts(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	legacyPaths, err := DefaultLegacyPaths()
+	if err != nil {
+		t.Fatalf("DefaultLegacyPaths returned error: %v", err)
+	}
+	legacySessionPath, err := bridge.DefaultLegacySessionFilePath()
+	if err != nil {
+		t.Fatalf("DefaultLegacySessionFilePath returned error: %v", err)
+	}
+	for _, path := range []string{legacyPaths.PlistPath, legacyPaths.SocketPath, legacySessionPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll failed: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("legacy"), 0o600); err != nil {
+			t.Fatalf("WriteFile failed: %v", err)
+		}
+	}
+	if err := os.MkdirAll(legacyPaths.SupportDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll support dir failed: %v", err)
+	}
+
+	_, paths := newShortPaths(t)
+	cfg := Config{
+		Paths:          paths,
+		Label:          LaunchAgentLabel,
+		IdleTimeout:    5 * time.Second,
+		ErrOut:         io.Discard,
+		Launchd:        blockingLaunchd{},
+		ExecutablePath: func() (string, error) { return "/tmp/xcodecli-test", nil },
+	}
+	status, err := StatusInfo(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("StatusInfo returned error: %v", err)
+	}
+	if !status.Legacy.PlistInstalled || !status.Legacy.SupportDirExists || !status.Legacy.SessionFileExists || !status.Legacy.SocketExists {
+		t.Fatalf("legacy status not detected: %+v", status.Legacy)
+	}
+}
+
+func TestUninstallRemovesLegacyArtifacts(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	legacyPaths, err := DefaultLegacyPaths()
+	if err != nil {
+		t.Fatalf("DefaultLegacyPaths returned error: %v", err)
+	}
+	legacySessionPath, err := bridge.DefaultLegacySessionFilePath()
+	if err != nil {
+		t.Fatalf("DefaultLegacySessionFilePath returned error: %v", err)
+	}
+	for _, path := range []string{legacyPaths.PlistPath, legacyPaths.SocketPath, legacyPaths.PIDPath, legacyPaths.LogPath, legacySessionPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("MkdirAll failed: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("legacy"), 0o600); err != nil {
+			t.Fatalf("WriteFile failed: %v", err)
+		}
+	}
+	if err := os.MkdirAll(legacyPaths.SupportDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll support dir failed: %v", err)
+	}
+
+	tempDir, paths := newShortPaths(t)
+	spawnFile := filepath.Join(tempDir, "spawn.log")
+	serverCfg := testServerConfig(t, paths, spawnFile, 5*time.Second)
+	harness := newServerHarness(t, serverCfg)
+	launchd := &fakeLaunchd{harness: harness}
+	clientCfg := testClientConfig(paths, spawnFile, 5*time.Second, launchd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := ListTools(ctx, clientCfg, Request{Timeout: 2 * time.Second}); err != nil {
+		t.Fatalf("ListTools returned error: %v", err)
+	}
+	if err := Uninstall(ctx, clientCfg); err != nil {
+		t.Fatalf("Uninstall returned error: %v", err)
+	}
+	for _, path := range []string{legacyPaths.PlistPath, legacyPaths.SocketPath, legacyPaths.PIDPath, legacyPaths.LogPath, legacySessionPath, legacyPaths.SupportDir} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected legacy artifact %s to be removed, stat err=%v", path, err)
+		}
+	}
+}
+
 func testClientConfig(paths Paths, spawnFile string, idleTimeout time.Duration, launchd Launchd) Config {
 	return Config{
 		Paths:       paths,
@@ -163,7 +252,7 @@ func testClientConfig(paths Paths, spawnFile string, idleTimeout time.Duration, 
 		),
 		ErrOut:         io.Discard,
 		Launchd:        launchd,
-		ExecutablePath: func() (string, error) { return "/tmp/xcodemcp-test", nil },
+		ExecutablePath: func() (string, error) { return "/tmp/xcodecli-test", nil },
 	}
 }
 
@@ -179,7 +268,7 @@ func testServerConfig(t *testing.T, paths Paths, spawnFile string, idleTimeout t
 			"AGENT_HELPER_SPAWN_FILE="+spawnFile,
 		),
 		ErrOut:         io.Discard,
-		ExecutablePath: func() (string, error) { return "/tmp/xcodemcp-test", nil },
+		ExecutablePath: func() (string, error) { return "/tmp/xcodecli-test", nil },
 	})
 	if err != nil {
 		t.Fatalf("normalizeConfig returned error: %v", err)

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 type unavailableError struct {
@@ -71,11 +72,16 @@ func StatusInfo(ctx context.Context, cfg Config) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
+	legacy, err := inspectLegacyArtifacts()
+	if err != nil {
+		return Status{}, err
+	}
 	status := Status{
 		Label:       cfg.Label,
 		PlistPath:   cfg.Paths.PlistPath,
 		SocketPath:  cfg.Paths.SocketPath,
 		IdleTimeout: cfg.IdleTimeout,
+		Legacy:      legacy,
 	}
 	if _, err := os.Stat(cfg.Paths.PlistPath); err == nil {
 		status.PlistInstalled = true
@@ -123,12 +129,76 @@ func Uninstall(ctx context.Context, cfg Config) error {
 	}
 	_ = Stop(ctx, cfg)
 	_ = cfg.Launchd.Bootout(ctx, launchAgentServiceTarget(cfg.Label))
-	for _, path := range []string{cfg.Paths.PlistPath, cfg.Paths.SocketPath, cfg.Paths.PIDPath, cfg.Paths.LogPath} {
+	legacyPaths, legacyErr := DefaultLegacyPaths()
+	if legacyErr == nil {
+		_ = cfg.Launchd.Bootout(ctx, launchAgentServiceTarget(LegacyLaunchAgentLabel))
+	}
+	pathsToRemove := []string{cfg.Paths.PlistPath, cfg.Paths.SocketPath, cfg.Paths.PIDPath, cfg.Paths.LogPath}
+	if sessionPath, sessionErr := bridge.DefaultSessionFilePath(); sessionErr == nil {
+		pathsToRemove = append(pathsToRemove, sessionPath)
+	}
+	if legacyErr == nil {
+		pathsToRemove = append(pathsToRemove, legacyPaths.PlistPath, legacyPaths.SocketPath, legacyPaths.PIDPath, legacyPaths.LogPath)
+	}
+	if legacySessionPath, sessionErr := bridge.DefaultLegacySessionFilePath(); sessionErr == nil {
+		pathsToRemove = append(pathsToRemove, legacySessionPath)
+	}
+	for _, path := range pathsToRemove {
+		if path == "" {
+			continue
+		}
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove %s: %w", path, err)
 		}
 	}
+	for _, dir := range []string{cfg.Paths.SupportDir, legacyPaths.SupportDir} {
+		if dir == "" {
+			continue
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("remove support directory %s: %w", dir, err)
+		}
+	}
 	return nil
+}
+
+func inspectLegacyArtifacts() (LegacyStatus, error) {
+	legacyPaths, err := DefaultLegacyPaths()
+	if err != nil {
+		return LegacyStatus{}, err
+	}
+	legacySessionPath, err := bridge.DefaultLegacySessionFilePath()
+	if err != nil {
+		return LegacyStatus{}, err
+	}
+	legacy := LegacyStatus{
+		Label:       LegacyLaunchAgentLabel,
+		PlistPath:   legacyPaths.PlistPath,
+		SupportDir:  legacyPaths.SupportDir,
+		SessionPath: legacySessionPath,
+		SocketPath:  legacyPaths.SocketPath,
+	}
+	if _, err := os.Stat(legacy.PlistPath); err == nil {
+		legacy.PlistInstalled = true
+	} else if !os.IsNotExist(err) {
+		return LegacyStatus{}, fmt.Errorf("inspect legacy launch agent plist: %w", err)
+	}
+	if _, err := os.Stat(legacy.SupportDir); err == nil {
+		legacy.SupportDirExists = true
+	} else if !os.IsNotExist(err) {
+		return LegacyStatus{}, fmt.Errorf("inspect legacy support directory: %w", err)
+	}
+	if _, err := os.Stat(legacy.SessionPath); err == nil {
+		legacy.SessionFileExists = true
+	} else if !os.IsNotExist(err) {
+		return LegacyStatus{}, fmt.Errorf("inspect legacy session file: %w", err)
+	}
+	if _, err := os.Stat(legacy.SocketPath); err == nil {
+		legacy.SocketExists = true
+	} else if !os.IsNotExist(err) {
+		return LegacyStatus{}, fmt.Errorf("inspect legacy socket path: %w", err)
+	}
+	return legacy, nil
 }
 
 func doWithAutostart(ctx context.Context, cfg Config, req rpcRequest) (rpcResponse, error) {

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -8,8 +8,11 @@ import (
 )
 
 const (
-	LaunchAgentLabel   = "io.oozoofrog.xcodemcp"
-	DefaultIdleTimeout = 10 * time.Minute
+	LaunchAgentLabel       = "io.oozoofrog.xcodecli"
+	LegacyLaunchAgentLabel = "io.oozoofrog.xcodemcp"
+	SupportDirName         = "xcodecli"
+	LegacySupportDirName   = "xcodemcp"
+	DefaultIdleTimeout     = 10 * time.Minute
 )
 
 type Paths struct {
@@ -28,13 +31,29 @@ func DefaultPaths() (Paths, error) {
 	return ResolvePaths(homeDir), nil
 }
 
+func DefaultLegacyPaths() (Paths, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return Paths{}, fmt.Errorf("resolve home directory for legacy agent paths: %w", err)
+	}
+	return ResolveLegacyPaths(homeDir), nil
+}
+
 func ResolvePaths(homeDir string) Paths {
-	supportDir := filepath.Join(homeDir, "Library", "Application Support", "xcodemcp")
+	return resolveNamedPaths(homeDir, SupportDirName, LaunchAgentLabel)
+}
+
+func ResolveLegacyPaths(homeDir string) Paths {
+	return resolveNamedPaths(homeDir, LegacySupportDirName, LegacyLaunchAgentLabel)
+}
+
+func resolveNamedPaths(homeDir, supportDirName, label string) Paths {
+	supportDir := filepath.Join(homeDir, "Library", "Application Support", supportDirName)
 	return Paths{
 		SupportDir: supportDir,
 		SocketPath: filepath.Join(supportDir, "daemon.sock"),
 		PIDPath:    filepath.Join(supportDir, "daemon.pid"),
 		LogPath:    filepath.Join(supportDir, "agent.log"),
-		PlistPath:  filepath.Join(homeDir, "Library", "LaunchAgents", LaunchAgentLabel+".plist"),
+		PlistPath:  filepath.Join(homeDir, "Library", "LaunchAgents", label+".plist"),
 	}
 }

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
-	"github.com/oozoofrog/xcodemcp-cli/internal/mcp"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
 type sessionKey struct {

--- a/internal/bridge/session.go
+++ b/internal/bridge/session.go
@@ -17,6 +17,7 @@ const (
 	SessionSourceEnv       SessionSource = "env"
 	SessionSourcePersisted SessionSource = "persisted"
 	SessionSourceGenerated SessionSource = "generated"
+	SessionSourceMigrated  SessionSource = "migrated"
 )
 
 type ResolvedOptions struct {
@@ -30,7 +31,15 @@ func DefaultSessionFilePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve home directory for session storage: %w", err)
 	}
-	return filepath.Join(homeDir, "Library", "Application Support", "xcodemcp", "session-id"), nil
+	return resolveSessionFilePath(homeDir, "xcodecli"), nil
+}
+
+func DefaultLegacySessionFilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for legacy session storage: %w", err)
+	}
+	return resolveSessionFilePath(homeDir, "xcodemcp"), nil
 }
 
 func ResolveOptions(baseEnv []string, overrides EnvOptions, sessionPath string) (ResolvedOptions, error) {
@@ -74,7 +83,17 @@ func loadOrCreateSessionID(path string) (string, SessionSource, error) {
 			return sessionID, SessionSourcePersisted, nil
 		}
 	case errors.Is(err, os.ErrNotExist):
-		// Create below.
+		defaultPath, defaultErr := DefaultSessionFilePath()
+		if defaultErr == nil && path == defaultPath {
+			legacyPath, legacyErr := DefaultLegacySessionFilePath()
+			if legacyErr == nil && legacyPath != "" && legacyPath != path {
+				if legacySessionID, migrated, migrateErr := migrateLegacySessionID(legacyPath, path); migrateErr != nil {
+					return "", SessionSourceUnset, migrateErr
+				} else if migrated {
+					return legacySessionID, SessionSourceMigrated, nil
+				}
+			}
+		}
 	default:
 		return "", SessionSourceUnset, fmt.Errorf("read persistent MCP_XCODE_SESSION_ID from %s: %w", path, err)
 	}
@@ -97,6 +116,28 @@ func persistSessionID(path, sessionID string) error {
 		return fmt.Errorf("write persistent MCP_XCODE_SESSION_ID to %s: %w", path, err)
 	}
 	return nil
+}
+
+func migrateLegacySessionID(legacyPath, newPath string) (string, bool, error) {
+	data, err := os.ReadFile(legacyPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read legacy MCP_XCODE_SESSION_ID from %s: %w", legacyPath, err)
+	}
+	sessionID := strings.TrimSpace(string(data))
+	if !IsValidUUID(sessionID) {
+		return "", false, nil
+	}
+	if err := persistSessionID(newPath, sessionID); err != nil {
+		return "", false, err
+	}
+	return sessionID, true, nil
+}
+
+func resolveSessionFilePath(homeDir, supportDirName string) string {
+	return filepath.Join(homeDir, "Library", "Application Support", supportDirName, "session-id")
 }
 
 func NewUUID() (string, error) {

--- a/internal/bridge/session_test.go
+++ b/internal/bridge/session_test.go
@@ -104,6 +104,45 @@ func TestResolveOptionsRepairsInvalidPersistedSessionID(t *testing.T) {
 	}
 }
 
+func TestResolveOptionsMigratesLegacyPersistedSessionID(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	legacyPath, err := DefaultLegacySessionFilePath()
+	if err != nil {
+		t.Fatalf("DefaultLegacySessionFilePath returned error: %v", err)
+	}
+	newPath, err := DefaultSessionFilePath()
+	if err != nil {
+		t.Fatalf("DefaultSessionFilePath returned error: %v", err)
+	}
+	want := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(want+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	resolved, err := ResolveOptions(nil, EnvOptions{}, newPath)
+	if err != nil {
+		t.Fatalf("ResolveOptions returned error: %v", err)
+	}
+	if resolved.SessionID != want {
+		t.Fatalf("SessionID = %q, want %q", resolved.SessionID, want)
+	}
+	if resolved.SessionSource != SessionSourceMigrated {
+		t.Fatalf("SessionSource = %q, want %q", resolved.SessionSource, SessionSourceMigrated)
+	}
+	data, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) failed: %v", newPath, err)
+	}
+	if got := string(data); got != want+"\n" {
+		t.Fatalf("persisted session content = %q, want %q", got, want+"\n")
+	}
+}
+
 func TestNewUUIDReturnsValidUUID(t *testing.T) {
 	value, err := NewUUID()
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -12,8 +12,8 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
 )
 
 type Status string
@@ -127,7 +127,7 @@ func (r Report) JSON() JSONReport {
 func (r Report) String() string {
 	summary := r.Summary()
 	var b strings.Builder
-	b.WriteString("xcodemcp doctor\n\n")
+	b.WriteString("xcodecli doctor\n\n")
 	for _, check := range r.Checks {
 		fmt.Fprintf(&b, "%s %s: %s\n", statusIcon(check.Status), check.Name, check.Detail)
 	}
@@ -238,6 +238,9 @@ func (i Inspector) Run(ctx context.Context, opts Options) Report {
 		if opts.AgentStatus.RegisteredBinary != "" || opts.AgentStatus.CurrentBinary != "" {
 			checks = append(checks, Check{Name: "LaunchAgent binary registration", Status: StatusInfo, Detail: fmt.Sprintf("registered=%s | current=%s | match=%t", opts.AgentStatus.RegisteredBinary, opts.AgentStatus.CurrentBinary, opts.AgentStatus.BinaryPathMatches)})
 		}
+		checks = append(checks, Check{Name: "Legacy LaunchAgent plist", Status: StatusInfo, Detail: fmt.Sprintf("installed=%t path=%s", opts.AgentStatus.Legacy.PlistInstalled, opts.AgentStatus.Legacy.PlistPath)})
+		checks = append(checks, Check{Name: "Legacy support directory", Status: StatusInfo, Detail: fmt.Sprintf("exists=%t path=%s", opts.AgentStatus.Legacy.SupportDirExists, opts.AgentStatus.Legacy.SupportDir)})
+		checks = append(checks, Check{Name: "Legacy session file", Status: StatusInfo, Detail: fmt.Sprintf("exists=%t path=%s", opts.AgentStatus.Legacy.SessionFileExists, opts.AgentStatus.Legacy.SessionPath)})
 	}
 
 	return Report{Checks: checks}
@@ -252,6 +255,10 @@ func formatSessionDetail(opts Options) string {
 	case bridge.SessionSourceGenerated:
 		if opts.SessionPath != "" {
 			return fmt.Sprintf("%s (generated and saved to %s)", opts.SessionID, opts.SessionPath)
+		}
+	case bridge.SessionSourceMigrated:
+		if opts.SessionPath != "" {
+			return fmt.Sprintf("%s (migrated from legacy xcodemcp storage into %s)", opts.SessionID, opts.SessionPath)
 		}
 	case bridge.SessionSourceEnv:
 		return fmt.Sprintf("%s (from environment)", opts.SessionID)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/oozoofrog/xcodemcp-cli/internal/agent"
-	"github.com/oozoofrog/xcodemcp-cli/internal/bridge"
+	"github.com/oozoofrog/xcodecli/internal/agent"
+	"github.com/oozoofrog/xcodecli/internal/bridge"
 )
 
 func TestReportString(t *testing.T) {
@@ -112,11 +112,11 @@ func TestInspectorIncludesAgentStatusInfo(t *testing.T) {
 	report := inspector.Run(context.Background(), Options{
 		AgentStatus: &agent.Status{
 			PlistInstalled:    true,
-			PlistPath:         "/tmp/io.oozoofrog.xcodemcp.plist",
+			PlistPath:         "/tmp/io.oozoofrog.xcodecli.plist",
 			SocketReachable:   true,
 			SocketPath:        "/tmp/daemon.sock",
-			RegisteredBinary:  "/tmp/xcodemcp",
-			CurrentBinary:     "/tmp/xcodemcp",
+			RegisteredBinary:  "/tmp/xcodecli",
+			CurrentBinary:     "/tmp/xcodecli",
 			BinaryPathMatches: true,
 		},
 	})

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -209,7 +209,7 @@ func (s *session) initialize() error {
 		"protocolVersion": requestProtocolVersion,
 		"capabilities":    map[string]any{},
 		"clientInfo": map[string]any{
-			"name":    "xcodemcp",
+			"name":    "xcodecli",
 			"version": "dev",
 		},
 	}, &result); err != nil {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PACKAGE="${PACKAGE:-./cmd/xcodemcp}"
-OUTPUT="${1:-${OUTPUT:-${ROOT_DIR}/xcodemcp}}"
+PACKAGE="${PACKAGE:-./cmd/xcodecli}"
+OUTPUT="${1:-${OUTPUT:-${ROOT_DIR}/xcodecli}}"
 
 mkdir -p "$(dirname "$OUTPUT")"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_REPO="oozoofrog/xcodemcp-cli"
+SOURCE_REPO="oozoofrog/xcodecli"
 DEFAULT_REF="main"
 
 usage() {
   cat <<'USAGE'
 Usage:
   ./scripts/install.sh [--bin-dir PATH] [--ref REF]
-  curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodemcp-cli/main/scripts/install.sh | bash
-  curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodemcp-cli/main/scripts/install.sh | bash -s -- --ref v0.2.1
+  curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodecli/main/scripts/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/oozoofrog/xcodecli/main/scripts/install.sh | bash -s -- --ref v0.3.0
 
 Options:
-  --bin-dir PATH   Install directory for the xcodemcp binary (default: $HOME/.local/bin)
+  --bin-dir PATH   Install directory for the xcodecli binary (default: $HOME/.local/bin)
   --ref REF        GitHub branch or tag to install when running outside a local checkout (default: main)
   -h, --help       Show help
 
 Environment:
   BIN_DIR          Same as --bin-dir
-  XCODEMCP_REF     Same as --ref
+  XCODECLI_REF     Same as --ref
 
 Behavior:
   - When run inside a local checkout and no --ref is provided, builds from the current working tree.
@@ -98,18 +98,27 @@ run_shell_path_check() {
   local shell_path="$1"
   local shell_name
   shell_name="$(basename "$shell_path")"
+  local marker_start="__XCODECLI_PATH_START__"
+  local marker_end="__XCODECLI_PATH_END__"
+  local raw_output=""
 
   case "$shell_name" in
     zsh|bash)
-      "$shell_path" -lic 'command -v xcodemcp || true' 2>/dev/null | sed -E $'s/\x1b\\[[0-9;]*[[:alpha:]]//g' | awk 'NF { line = $0 } END { print line }'
+      raw_output="$("$shell_path" -lic "printf '%s\n' '${marker_start}'; command -v xcodecli || true; printf '%s\n' '${marker_end}'" 2>/dev/null | sed -E $'s/\x1b\\[[0-9;]*[[:alpha:]]//g')"
       ;;
     fish)
-      "$shell_path" -lc 'command -v xcodemcp; true' 2>/dev/null | sed -E $'s/\x1b\\[[0-9;]*[[:alpha:]]//g' | awk 'NF { line = $0 } END { print line }'
+      raw_output="$("$shell_path" -lc "printf '%s\n' '${marker_start}'; command -v xcodecli; true; printf '%s\n' '${marker_end}'" 2>/dev/null | sed -E $'s/\x1b\\[[0-9;]*[[:alpha:]]//g')"
       ;;
     *)
       return 1
       ;;
   esac
+
+  awk -v start="$marker_start" -v end="$marker_end" '
+    $0 == start { capture = 1; next }
+    $0 == end { capture = 0; exit }
+    capture && NF { print; exit }
+  ' <<< "$raw_output"
 }
 
 print_path_guidance() {
@@ -149,18 +158,18 @@ report_path_status() {
   log "checking PATH integration"
 
   local current_hit=""
-  current_hit="$(command -v xcodemcp 2>/dev/null || true)"
+  current_hit="$(command -v xcodecli 2>/dev/null || true)"
   if [[ -n "$current_hit" ]]; then
     local current_resolved=""
     current_resolved="$(resolve_path "$current_hit" 2>/dev/null || true)"
     if [[ "$current_resolved" == "$install_resolved" ]]; then
-      log "current session PATH resolves xcodemcp -> ${current_resolved}"
+      log "current session PATH resolves xcodecli -> ${current_resolved}"
     else
-      log "warning: current session PATH resolves xcodemcp -> ${current_hit}"
+      log "warning: current session PATH resolves xcodecli -> ${current_hit}"
       log "warning: newly installed binary is ${install_resolved}"
     fi
   else
-    log "current session PATH does not yet resolve xcodemcp"
+    log "current session PATH does not yet resolve xcodecli"
   fi
 
   local preferred_shell=""
@@ -179,25 +188,25 @@ report_path_status() {
     local shell_resolved=""
     shell_resolved="$(resolve_path "$shell_hit" 2>/dev/null || true)"
     if [[ "$shell_resolved" == "$install_resolved" ]]; then
-      log "${shell_name} login shell resolves xcodemcp -> ${shell_resolved}"
+      log "${shell_name} login shell resolves xcodecli -> ${shell_resolved}"
       if [[ -z "$current_hit" ]]; then
         log "open a new terminal window or restart your shell to pick up the updated PATH"
       fi
       return 0
     fi
-    log "warning: ${shell_name} login shell resolves xcodemcp -> ${shell_hit}"
+    log "warning: ${shell_name} login shell resolves xcodecli -> ${shell_hit}"
     log "warning: newly installed binary is ${install_resolved}"
     log "you may need to move ${install_bin_dir} earlier in PATH"
     print_path_guidance "$shell_name" "$install_bin_dir"
     return 0
   fi
 
-  log "warning: ${shell_name} login shell could not find xcodemcp on PATH"
+  log "warning: ${shell_name} login shell could not find xcodecli on PATH"
   print_path_guidance "$shell_name" "$install_bin_dir"
 }
 
 BIN_DIR="${BIN_DIR:-$HOME/.local/bin}"
-REF="${XCODEMCP_REF:-}"
+REF="${XCODECLI_REF:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -221,7 +230,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ "$(uname -s)" == "Darwin" ]] || fail "xcodemcp only supports macOS"
+[[ "$(uname -s)" == "Darwin" ]] || fail "xcodecli only supports macOS"
 
 require_cmd go
 
@@ -256,7 +265,7 @@ else
   require_cmd tar
   REF="${REF:-$DEFAULT_REF}"
   ARCHIVE_URL="$(resolve_archive_url "$REF")"
-  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/xcodemcp-install-XXXXXX")"
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/xcodecli-install-XXXXXX")"
   TARBALL_PATH="${WORK_DIR}/source.tar.gz"
   log "downloading ${ARCHIVE_URL}"
   curl -fsSL "$ARCHIVE_URL" -o "$TARBALL_PATH"
@@ -268,13 +277,13 @@ else
 fi
 
 INSTALL_BIN_DIR="$(mkdir -p "$BIN_DIR" && cd "$BIN_DIR" >/dev/null 2>&1 && pwd)"
-TEMP_OUTPUT="${WORK_DIR:-${TMPDIR:-/tmp}}/xcodemcp"
+TEMP_OUTPUT="${WORK_DIR:-${TMPDIR:-/tmp}}/xcodecli"
 rm -f "$TEMP_OUTPUT"
 
-log "building xcodemcp"
+log "building xcodecli"
 "${BUILD_ROOT}/scripts/build.sh" "$TEMP_OUTPUT"
 
-INSTALL_PATH="${INSTALL_BIN_DIR}/xcodemcp"
+INSTALL_PATH="${INSTALL_BIN_DIR}/xcodecli"
 log "installing to ${INSTALL_PATH}"
 install -m 0755 "$TEMP_OUTPUT" "$INSTALL_PATH"
 

--- a/scripts/release_homebrew.sh
+++ b/scripts/release_homebrew.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOURCE_REPO="oozoofrog/xcodemcp-cli"
+SOURCE_REPO="oozoofrog/xcodecli"
 export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 TAP_REPO="oozoofrog/homebrew-tap"
-FORMULA_NAME="xcodemcp"
+FORMULA_NAME="xcodecli"
+LEGACY_FORMULA_NAME="xcodemcp"
 DEFAULT_CLONE_ROOT="${TMPDIR:-/tmp}"
 
 usage() {
@@ -15,14 +16,15 @@ Usage:
   ./scripts/release_homebrew.sh <tag> [--tap-dir PATH] [--push] [--dry-run]
 
 Examples:
-  ./scripts/release_homebrew.sh v0.2.0 --tap-dir .tmp/homebrew-tap --dry-run
-  ./scripts/release_homebrew.sh v0.2.1 --push
+  ./scripts/release_homebrew.sh v0.3.0 --tap-dir .tmp/homebrew-tap --dry-run
+  ./scripts/release_homebrew.sh v0.3.0 --push
 
 Behavior:
   - Downloads the GitHub source tarball for the given tag
-  - Computes sha256 and writes Formula/xcodemcp.rb in the shared tap repo
+  - Computes sha256 and writes Formula/xcodecli.rb in the shared tap repo
+  - Removes Formula/xcodemcp.rb during the rename cutover
   - Runs Homebrew audit and build-from-source validation
-  - Commits only the xcodemcp formula change locally unless --dry-run is set
+  - Commits the xcodecli formula add/update plus any xcodemcp formula removal unless --dry-run is set
   - Pushes the tap commit only when --push is set
 
 Environment:
@@ -67,6 +69,7 @@ ensure_git_identity() {
 ensure_tap_repo_safe() {
   local tap_dir="$1"
   local formula_rel="Formula/${FORMULA_NAME}.rb"
+  local legacy_formula_rel="Formula/${LEGACY_FORMULA_NAME}.rb"
   local status
   status="$(git -C "$tap_dir" status --short)"
   if [[ -z "$status" ]]; then
@@ -76,7 +79,7 @@ ensure_tap_repo_safe() {
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     local path_part="${line:3}"
-    if [[ "$path_part" != "$formula_rel" ]]; then
+    if [[ "$path_part" != "$formula_rel" && "$path_part" != "$legacy_formula_rel" ]]; then
       fail "tap repo has unrelated local changes: $line"
     fi
   done <<< "$status"
@@ -86,7 +89,7 @@ render_formula() {
   local version="$1"
   local sha256="$2"
   cat <<FORMULA
-class Xcodemcp < Formula
+class Xcodecli < Formula
   desc "Go CLI wrapper around xcrun mcpbridge"
   homepage "https://github.com/${SOURCE_REPO}"
   url "https://github.com/${SOURCE_REPO}/archive/refs/tags/v${version}.tar.gz"
@@ -96,12 +99,12 @@ class Xcodemcp < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(output: bin/"xcodemcp"), "./cmd/xcodemcp"
+    system "go", "build", *std_go_args(output: bin/"xcodecli"), "./cmd/xcodecli"
   end
 
   test do
-    output = shell_output("#{bin}/xcodemcp help")
-    assert_match "xcodemcp wraps xcrun mcpbridge", output
+    output = shell_output("#{bin}/xcodecli help")
+    assert_match "xcodecli wraps xcrun mcpbridge", output
   end
 end
 FORMULA
@@ -156,7 +159,7 @@ require_cmd brew
 TAP_NAME="oozoofrog/tap"
 AUTO_CLONED=0
 if [[ -z "$TAP_DIR" ]]; then
-  TAP_DIR="$(mktemp -d "${DEFAULT_CLONE_ROOT%/}/xcodemcp-homebrew-tap-XXXXXX")"
+  TAP_DIR="$(mktemp -d "${DEFAULT_CLONE_ROOT%/}/xcodecli-homebrew-tap-XXXXXX")"
   AUTO_CLONED=1
   log "cloning ${TAP_REPO} into ${TAP_DIR}"
   clone_tap_repo "$TAP_DIR"
@@ -166,6 +169,7 @@ fi
 ensure_tap_repo_safe "$TAP_DIR"
 mkdir -p "$TAP_DIR/Formula"
 FORMULA_PATH="$TAP_DIR/Formula/${FORMULA_NAME}.rb"
+LEGACY_FORMULA_PATH="$TAP_DIR/Formula/${LEGACY_FORMULA_NAME}.rb"
 TARBALL_URL="https://github.com/${SOURCE_REPO}/archive/refs/tags/${TAG}.tar.gz"
 
 log "computing sha256 for ${TARBALL_URL}"
@@ -174,6 +178,10 @@ SHA256="$(curl -fsSL "$TARBALL_URL" | shasum -a 256 | awk '{print $1}')"
 
 log "writing ${FORMULA_PATH} inside shared tap repo ${TAP_DIR}"
 render_formula "$VERSION" "$SHA256" > "$FORMULA_PATH"
+if [[ -f "$LEGACY_FORMULA_PATH" ]]; then
+  log "removing legacy formula ${LEGACY_FORMULA_PATH}"
+  rm -f "$LEGACY_FORMULA_PATH"
+fi
 
 VALIDATION_TAP_ADDED=0
 if ! brew tap | grep -qx "$TAP_NAME"; then
@@ -189,7 +197,7 @@ VALIDATION_FORMULA_PATH="$VALIDATION_FORMULA_DIR/${FORMULA_NAME}.rb"
 BACKUP_FORMULA_PATH=""
 mkdir -p "$VALIDATION_FORMULA_DIR"
 if [[ -f "$VALIDATION_FORMULA_PATH" ]]; then
-  BACKUP_FORMULA_PATH="$(mktemp "${DEFAULT_CLONE_ROOT%/}/xcodemcp-formula-backup-XXXXXX.rb")"
+  BACKUP_FORMULA_PATH="$(mktemp "${DEFAULT_CLONE_ROOT%/}/xcodecli-formula-backup-XXXXXX.rb")"
   cp "$VALIDATION_FORMULA_PATH" "$BACKUP_FORMULA_PATH"
 fi
 log "temporarily validating only ${VALIDATION_FORMULA_PATH}"
@@ -230,7 +238,7 @@ if [[ "$WAS_INSTALLED" -eq 0 ]]; then
   brew uninstall --force "$FORMULA_NAME"
 fi
 
-if [[ -z "$(git -C "$TAP_DIR" status --short -- "Formula/${FORMULA_NAME}.rb")" ]]; then
+if [[ -z "$(git -C "$TAP_DIR" status --short -- "Formula/${FORMULA_NAME}.rb" "Formula/${LEGACY_FORMULA_NAME}.rb")" ]]; then
   log "formula already up to date"
 else
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -238,7 +246,7 @@ else
   else
     ensure_git_identity "$TAP_DIR"
     ensure_tap_repo_safe "$TAP_DIR"
-    git -C "$TAP_DIR" add "Formula/${FORMULA_NAME}.rb"
+    git -C "$TAP_DIR" add -A "Formula/${FORMULA_NAME}.rb" "Formula/${LEGACY_FORMULA_NAME}.rb"
     git -C "$TAP_DIR" commit -m "${FORMULA_NAME} ${VERSION}"
     if [[ "$PUSH" -eq 1 ]]; then
       log "rebasing tap branch before push"


### PR DESCRIPTION
## Summary
- rename the public CLI, Go module, docs, scripts, and repo references from `xcodemcp` to `xcodecli`
- rename LaunchAgent/runtime identifiers and add legacy `xcodemcp` session + artifact migration/cleanup reporting
- update install/Homebrew release automation for `xcodecli`, including removal of the legacy tap formula during cutover

Closes #11

## Testing
- go test ./...
- ./scripts/build.sh
- ./xcodecli --help
- ./scripts/install.sh --bin-dir <temp dir>
- ./scripts/install.sh --ref codex/rename-xcodemcp-to-xcodecli --bin-dir <temp dir>