### PR TITLE
Remove migration references from xcodecli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - `agent guide` subcommand for read-only workflow tutoring that maps a request to the recommended xcodecli tool sequence and prints exact next commands.
 - `agent demo` subcommand for a safe read-only onboarding flow that runs `doctor`, lists live MCP tools, calls `XcodeListWindows`, and prints suggested next commands.
 - `scripts/install.sh` for installing `xcodecli` from a local checkout or directly from GitHub source refs.
-- Legacy session migration from `~/Library/Application Support/xcodemcp/session-id` into the new `xcodecli` runtime location.
 
 ### Changed
-- **Breaking rename:** the project, GitHub repository, CLI binary, LaunchAgent runtime identifiers, and Homebrew formula all move from `xcodemcp` to `xcodecli`.
 - Improved first-run onboarding docs and root CLI help with a guide-first path for humans and agents, while keeping `agent demo` as the safe live discovery step.
 - Moved installation guidance near the top of the README and documented both direct GitHub installs and Homebrew installs.
 - `scripts/install.sh` now verifies PATH reachability for the user's login shell and prints shell-specific next steps when `xcodecli` is not discoverable on PATH.
-- `agent status`, `doctor`, and `agent uninstall` now detect and clean up legacy `xcodemcp` LaunchAgent/support artifacts.
-- Homebrew release automation now publishes `oozoofrog/tap/xcodecli` and removes the legacy `xcodemcp` formula during the rename cutover.
+- Homebrew release automation now publishes `oozoofrog/tap/xcodecli`.
 
 ## [0.2.1] - 2026-03-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,13 +59,6 @@ The install script:
 
 The shared `oozoofrog/tap` repository can host multiple formulas and casks. `xcodecli` is published there as `Formula/xcodecli.rb`.
 
-If you are upgrading from the old `xcodemcp` name, switch with:
-
-```bash
-brew uninstall xcodemcp || true
-brew install oozoofrog/tap/xcodecli
-```
-
 If a release needs to be synced manually, see `docs/releasing.md` and `./scripts/release_homebrew.sh`.
 
 ## Build from source
@@ -198,23 +191,21 @@ After `agent guide` and `agent demo`, the next likely usability improvement is a
 
 ## Versioning strategy
 
-Starting with the `xcodecli` rename release, the project continues to use pre-1.0 semantic versioning tags with the following release policy:
+The project continues to use pre-1.0 semantic versioning tags with the following release policy:
 
 - `v0.2.1`, `v0.2.2`, ...: patch releases for bug fixes, CI/test hardening, documentation corrections, and internal refactors that do not intentionally expand the public CLI surface.
 - `v0.3.0`, `v0.4.0`, ...: minor releases for new commands, new flags, new output modes, default-behavior expansions, or materially new LaunchAgent / MCP capabilities.
 - Breaking CLI behavior is avoided when possible. Before `v1.0.0`, any unavoidable breaking change should ship in a new minor release and must be called out explicitly in `CHANGELOG.md` and the GitHub Release notes.
 - Releases should be cut from `main` only after CI is green.
 - Tags should remain annotated `vMAJOR.MINOR.PATCH` tags, and GitHub Releases should continue to use generated notes unless a release needs hand-written upgrade guidance.
-- The active maintenance line after this breaking rename is `v0.3.x`. Small fixes should prefer the next patch tag on that line before opening a new minor series.
+- The active maintenance line is `v0.3.x`. Small fixes should prefer the next patch tag on that line before opening a new minor series.
 
 ## Notes
 
 - `--xcode-pid` overrides `MCP_XCODE_PID`.
 - `--session-id` overrides `MCP_XCODE_SESSION_ID`.
 - If no `--session-id` flag or `MCP_XCODE_SESSION_ID` environment variable is provided, `xcodecli` automatically creates and reuses a persistent session ID at `~/Library/Application Support/xcodecli/session-id`.
-- If an older `~/Library/Application Support/xcodemcp/session-id` exists, `xcodecli` copies it once into the new `xcodecli` location.
 - In bridge mode, **stdout is protocol-only**. Wrapper logs and diagnostics go to stderr.
 - Convenience commands (`tools list`, `tool inspect`, `tool call`) automatically install and bootstrap a per-user LaunchAgent at `~/Library/LaunchAgents/io.oozoofrog.xcodecli.plist`.
-- `xcodecli agent status` and `xcodecli doctor` also report whether legacy `xcodemcp` LaunchAgent/support artifacts are still present.
 - The LaunchAgent talks to `xcrun mcpbridge` over a long-lived local Unix socket and shuts itself down after `10m` of idleness by default.
 - `tool call` accepts exactly one payload source: inline `--json`, `--json @file`, or `--json-stdin`.

--- a/cmd/xcodecli/main.go
+++ b/cmd/xcodecli/main.go
@@ -268,7 +268,7 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 			fmt.Fprintf(stderr, "xcodecli: %v\n", err)
 			return 1
 		}
-		fmt.Fprintln(stdout, "removed xcodecli LaunchAgent/runtime files and any legacy xcodemcp artifacts")
+		fmt.Fprintln(stdout, "removed LaunchAgent plist and local agent runtime files")
 		return 0
 	case commandAgentRun:
 		signalCtx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
@@ -366,8 +366,6 @@ func logResolvedSession(w io.Writer, resolved bridge.ResolvedOptions) {
 		fmt.Fprintf(w, "[debug] using persisted MCP_XCODE_SESSION_ID %s from %s\n", resolved.SessionID, resolved.SessionPath)
 	case bridge.SessionSourceGenerated:
 		fmt.Fprintf(w, "[debug] generated persistent MCP_XCODE_SESSION_ID %s at %s\n", resolved.SessionID, resolved.SessionPath)
-	case bridge.SessionSourceMigrated:
-		fmt.Fprintf(w, "[debug] migrated persistent MCP_XCODE_SESSION_ID %s into %s from legacy xcodemcp storage\n", resolved.SessionID, resolved.SessionPath)
 	}
 }
 
@@ -392,7 +390,7 @@ func formatAgentStatus(status agent.Status) string {
 	if status.SocketReachable {
 		socketText = "yes"
 	}
-	return fmt.Sprintf("xcodecli agent\n\nlabel: %s\nplist installed: %t\nplist path: %s\nregistered binary: %s\ncurrent binary: %s\nbinary matches: %s\nsocket path: %s\nsocket reachable: %s\nrunning: %s\npid: %d\nidle timeout: %s\nbackend sessions: %d\nlegacy label: %s\nlegacy plist installed: %t\nlegacy plist path: %s\nlegacy support dir: %s (exists=%t)\nlegacy session path: %s (exists=%t)\nlegacy socket path: %s (exists=%t)\n",
+	return fmt.Sprintf("xcodecli agent\n\nlabel: %s\nplist installed: %t\nplist path: %s\nregistered binary: %s\ncurrent binary: %s\nbinary matches: %s\nsocket path: %s\nsocket reachable: %s\nrunning: %s\npid: %d\nidle timeout: %s\nbackend sessions: %d\n",
 		status.Label,
 		status.PlistInstalled,
 		status.PlistPath,
@@ -405,15 +403,6 @@ func formatAgentStatus(status agent.Status) string {
 		status.PID,
 		status.IdleTimeout,
 		status.BackendSessions,
-		status.Legacy.Label,
-		status.Legacy.PlistInstalled,
-		status.Legacy.PlistPath,
-		status.Legacy.SupportDir,
-		status.Legacy.SupportDirExists,
-		status.Legacy.SessionPath,
-		status.Legacy.SessionFileExists,
-		status.Legacy.SocketPath,
-		status.Legacy.SocketExists,
 	)
 }
 

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -125,10 +125,6 @@ If you want the next mutating step after discovery, that is where you would choo
 
 Then retry `tools list` or `tool inspect`.
 
-### Legacy rename cleanup
-- If you previously used `xcodemcp`, run `./xcodecli agent uninstall` once to remove old LaunchAgent/runtime artifacts.
-- `./xcodecli doctor --json` and `./xcodecli agent status --json` will tell you whether any legacy `xcodemcp` files still exist.
-
 ### The payload is large or reused often
 Prefer `--json @file` over a huge inline string.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,9 +23,8 @@ The automation path is:
 
 - GitHub Release published in `oozoofrog/xcodecli`
 - `.github/workflows/homebrew-release.yml` runs
-- `scripts/release_homebrew.sh <tag> --push` updates the tap formula and removes the legacy `xcodemcp` formula during cutover
+- `scripts/release_homebrew.sh <tag> --push` updates the tap formula
 - `oozoofrog/homebrew-tap/Formula/xcodecli.rb` is committed and pushed
-- `oozoofrog/homebrew-tap/Formula/xcodemcp.rb` is removed
 - other formulas/casks in the shared tap are left untouched
 
 ## Manual recovery / local dry-run
@@ -59,7 +58,7 @@ The token must be able to push to `oozoofrog/homebrew-tap`.
 ## Shared tap safety rules
 
 - Treat `oozoofrog/homebrew-tap` as a shared repository for multiple projects.
-- Only `Formula/xcodecli.rb` should be created or updated, and `Formula/xcodemcp.rb` may be removed, by the `xcodecli` release flow.
+- Only `Formula/xcodecli.rb` should be created or updated by the `xcodecli` release flow.
 - Validation temporarily backs up and restores only `Formula/xcodecli.rb` inside the local Homebrew tap checkout.
 - If the tap clone has unrelated local changes, the release script should stop instead of mixing `xcodecli` changes with other tap edits.
-- If validation or push fails, recover by re-running `./scripts/release_homebrew.sh <tag> --tap-dir <tap clone> --dry-run` and checking the `Formula/xcodecli.rb` add/update plus any `Formula/xcodemcp.rb` removal.
+- If validation or push fails, recover by re-running `./scripts/release_homebrew.sh <tag> --tap-dir <tap clone> --dry-run` and checking only the `Formula/xcodecli.rb` diff.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -48,19 +48,6 @@ type Status struct {
 	PID               int           `json:"pid"`
 	IdleTimeout       time.Duration `json:"idleTimeout"`
 	BackendSessions   int           `json:"backendSessions"`
-	Legacy            LegacyStatus  `json:"legacy"`
-}
-
-type LegacyStatus struct {
-	Label             string `json:"label"`
-	PlistPath         string `json:"plistPath"`
-	PlistInstalled    bool   `json:"plistInstalled"`
-	SupportDir        string `json:"supportDir"`
-	SupportDirExists  bool   `json:"supportDirExists"`
-	SessionPath       string `json:"sessionPath"`
-	SessionFileExists bool   `json:"sessionFileExists"`
-	SocketPath        string `json:"socketPath"`
-	SocketExists      bool   `json:"socketExists"`
 }
 
 type runtimeStatus struct {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oozoofrog/xcodecli/internal/bridge"
 	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
@@ -148,94 +147,6 @@ func TestUninstallRemovesLaunchAgentArtifacts(t *testing.T) {
 	for _, path := range []string{paths.PlistPath, paths.SocketPath, paths.PIDPath} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("expected %s to be removed, stat err=%v", path, err)
-		}
-	}
-}
-
-func TestStatusInfoIncludesLegacyArtifacts(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-
-	legacyPaths, err := DefaultLegacyPaths()
-	if err != nil {
-		t.Fatalf("DefaultLegacyPaths returned error: %v", err)
-	}
-	legacySessionPath, err := bridge.DefaultLegacySessionFilePath()
-	if err != nil {
-		t.Fatalf("DefaultLegacySessionFilePath returned error: %v", err)
-	}
-	for _, path := range []string{legacyPaths.PlistPath, legacyPaths.SocketPath, legacySessionPath} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll failed: %v", err)
-		}
-		if err := os.WriteFile(path, []byte("legacy"), 0o600); err != nil {
-			t.Fatalf("WriteFile failed: %v", err)
-		}
-	}
-	if err := os.MkdirAll(legacyPaths.SupportDir, 0o700); err != nil {
-		t.Fatalf("MkdirAll support dir failed: %v", err)
-	}
-
-	_, paths := newShortPaths(t)
-	cfg := Config{
-		Paths:          paths,
-		Label:          LaunchAgentLabel,
-		IdleTimeout:    5 * time.Second,
-		ErrOut:         io.Discard,
-		Launchd:        blockingLaunchd{},
-		ExecutablePath: func() (string, error) { return "/tmp/xcodecli-test", nil },
-	}
-	status, err := StatusInfo(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("StatusInfo returned error: %v", err)
-	}
-	if !status.Legacy.PlistInstalled || !status.Legacy.SupportDirExists || !status.Legacy.SessionFileExists || !status.Legacy.SocketExists {
-		t.Fatalf("legacy status not detected: %+v", status.Legacy)
-	}
-}
-
-func TestUninstallRemovesLegacyArtifacts(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-
-	legacyPaths, err := DefaultLegacyPaths()
-	if err != nil {
-		t.Fatalf("DefaultLegacyPaths returned error: %v", err)
-	}
-	legacySessionPath, err := bridge.DefaultLegacySessionFilePath()
-	if err != nil {
-		t.Fatalf("DefaultLegacySessionFilePath returned error: %v", err)
-	}
-	for _, path := range []string{legacyPaths.PlistPath, legacyPaths.SocketPath, legacyPaths.PIDPath, legacyPaths.LogPath, legacySessionPath} {
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatalf("MkdirAll failed: %v", err)
-		}
-		if err := os.WriteFile(path, []byte("legacy"), 0o600); err != nil {
-			t.Fatalf("WriteFile failed: %v", err)
-		}
-	}
-	if err := os.MkdirAll(legacyPaths.SupportDir, 0o700); err != nil {
-		t.Fatalf("MkdirAll support dir failed: %v", err)
-	}
-
-	tempDir, paths := newShortPaths(t)
-	spawnFile := filepath.Join(tempDir, "spawn.log")
-	serverCfg := testServerConfig(t, paths, spawnFile, 5*time.Second)
-	harness := newServerHarness(t, serverCfg)
-	launchd := &fakeLaunchd{harness: harness}
-	clientCfg := testClientConfig(paths, spawnFile, 5*time.Second, launchd)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if _, err := ListTools(ctx, clientCfg, Request{Timeout: 2 * time.Second}); err != nil {
-		t.Fatalf("ListTools returned error: %v", err)
-	}
-	if err := Uninstall(ctx, clientCfg); err != nil {
-		t.Fatalf("Uninstall returned error: %v", err)
-	}
-	for _, path := range []string{legacyPaths.PlistPath, legacyPaths.SocketPath, legacyPaths.PIDPath, legacyPaths.LogPath, legacySessionPath, legacyPaths.SupportDir} {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			t.Fatalf("expected legacy artifact %s to be removed, stat err=%v", path, err)
 		}
 	}
 }

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oozoofrog/xcodecli/internal/bridge"
 	"github.com/oozoofrog/xcodecli/internal/mcp"
 )
 
@@ -72,16 +71,11 @@ func StatusInfo(ctx context.Context, cfg Config) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	legacy, err := inspectLegacyArtifacts()
-	if err != nil {
-		return Status{}, err
-	}
 	status := Status{
 		Label:       cfg.Label,
 		PlistPath:   cfg.Paths.PlistPath,
 		SocketPath:  cfg.Paths.SocketPath,
 		IdleTimeout: cfg.IdleTimeout,
-		Legacy:      legacy,
 	}
 	if _, err := os.Stat(cfg.Paths.PlistPath); err == nil {
 		status.PlistInstalled = true
@@ -129,20 +123,7 @@ func Uninstall(ctx context.Context, cfg Config) error {
 	}
 	_ = Stop(ctx, cfg)
 	_ = cfg.Launchd.Bootout(ctx, launchAgentServiceTarget(cfg.Label))
-	legacyPaths, legacyErr := DefaultLegacyPaths()
-	if legacyErr == nil {
-		_ = cfg.Launchd.Bootout(ctx, launchAgentServiceTarget(LegacyLaunchAgentLabel))
-	}
 	pathsToRemove := []string{cfg.Paths.PlistPath, cfg.Paths.SocketPath, cfg.Paths.PIDPath, cfg.Paths.LogPath}
-	if sessionPath, sessionErr := bridge.DefaultSessionFilePath(); sessionErr == nil {
-		pathsToRemove = append(pathsToRemove, sessionPath)
-	}
-	if legacyErr == nil {
-		pathsToRemove = append(pathsToRemove, legacyPaths.PlistPath, legacyPaths.SocketPath, legacyPaths.PIDPath, legacyPaths.LogPath)
-	}
-	if legacySessionPath, sessionErr := bridge.DefaultLegacySessionFilePath(); sessionErr == nil {
-		pathsToRemove = append(pathsToRemove, legacySessionPath)
-	}
 	for _, path := range pathsToRemove {
 		if path == "" {
 			continue
@@ -151,7 +132,7 @@ func Uninstall(ctx context.Context, cfg Config) error {
 			return fmt.Errorf("remove %s: %w", path, err)
 		}
 	}
-	for _, dir := range []string{cfg.Paths.SupportDir, legacyPaths.SupportDir} {
+	for _, dir := range []string{cfg.Paths.SupportDir} {
 		if dir == "" {
 			continue
 		}
@@ -160,45 +141,6 @@ func Uninstall(ctx context.Context, cfg Config) error {
 		}
 	}
 	return nil
-}
-
-func inspectLegacyArtifacts() (LegacyStatus, error) {
-	legacyPaths, err := DefaultLegacyPaths()
-	if err != nil {
-		return LegacyStatus{}, err
-	}
-	legacySessionPath, err := bridge.DefaultLegacySessionFilePath()
-	if err != nil {
-		return LegacyStatus{}, err
-	}
-	legacy := LegacyStatus{
-		Label:       LegacyLaunchAgentLabel,
-		PlistPath:   legacyPaths.PlistPath,
-		SupportDir:  legacyPaths.SupportDir,
-		SessionPath: legacySessionPath,
-		SocketPath:  legacyPaths.SocketPath,
-	}
-	if _, err := os.Stat(legacy.PlistPath); err == nil {
-		legacy.PlistInstalled = true
-	} else if !os.IsNotExist(err) {
-		return LegacyStatus{}, fmt.Errorf("inspect legacy launch agent plist: %w", err)
-	}
-	if _, err := os.Stat(legacy.SupportDir); err == nil {
-		legacy.SupportDirExists = true
-	} else if !os.IsNotExist(err) {
-		return LegacyStatus{}, fmt.Errorf("inspect legacy support directory: %w", err)
-	}
-	if _, err := os.Stat(legacy.SessionPath); err == nil {
-		legacy.SessionFileExists = true
-	} else if !os.IsNotExist(err) {
-		return LegacyStatus{}, fmt.Errorf("inspect legacy session file: %w", err)
-	}
-	if _, err := os.Stat(legacy.SocketPath); err == nil {
-		legacy.SocketExists = true
-	} else if !os.IsNotExist(err) {
-		return LegacyStatus{}, fmt.Errorf("inspect legacy socket path: %w", err)
-	}
-	return legacy, nil
 }
 
 func doWithAutostart(ctx context.Context, cfg Config, req rpcRequest) (rpcResponse, error) {

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -8,11 +8,9 @@ import (
 )
 
 const (
-	LaunchAgentLabel       = "io.oozoofrog.xcodecli"
-	LegacyLaunchAgentLabel = "io.oozoofrog.xcodemcp"
-	SupportDirName         = "xcodecli"
-	LegacySupportDirName   = "xcodemcp"
-	DefaultIdleTimeout     = 10 * time.Minute
+	LaunchAgentLabel   = "io.oozoofrog.xcodecli"
+	SupportDirName     = "xcodecli"
+	DefaultIdleTimeout = 10 * time.Minute
 )
 
 type Paths struct {
@@ -31,20 +29,8 @@ func DefaultPaths() (Paths, error) {
 	return ResolvePaths(homeDir), nil
 }
 
-func DefaultLegacyPaths() (Paths, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return Paths{}, fmt.Errorf("resolve home directory for legacy agent paths: %w", err)
-	}
-	return ResolveLegacyPaths(homeDir), nil
-}
-
 func ResolvePaths(homeDir string) Paths {
 	return resolveNamedPaths(homeDir, SupportDirName, LaunchAgentLabel)
-}
-
-func ResolveLegacyPaths(homeDir string) Paths {
-	return resolveNamedPaths(homeDir, LegacySupportDirName, LegacyLaunchAgentLabel)
 }
 
 func resolveNamedPaths(homeDir, supportDirName, label string) Paths {

--- a/internal/bridge/session.go
+++ b/internal/bridge/session.go
@@ -17,7 +17,6 @@ const (
 	SessionSourceEnv       SessionSource = "env"
 	SessionSourcePersisted SessionSource = "persisted"
 	SessionSourceGenerated SessionSource = "generated"
-	SessionSourceMigrated  SessionSource = "migrated"
 )
 
 type ResolvedOptions struct {
@@ -32,14 +31,6 @@ func DefaultSessionFilePath() (string, error) {
 		return "", fmt.Errorf("resolve home directory for session storage: %w", err)
 	}
 	return resolveSessionFilePath(homeDir, "xcodecli"), nil
-}
-
-func DefaultLegacySessionFilePath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory for legacy session storage: %w", err)
-	}
-	return resolveSessionFilePath(homeDir, "xcodemcp"), nil
 }
 
 func ResolveOptions(baseEnv []string, overrides EnvOptions, sessionPath string) (ResolvedOptions, error) {
@@ -83,17 +74,7 @@ func loadOrCreateSessionID(path string) (string, SessionSource, error) {
 			return sessionID, SessionSourcePersisted, nil
 		}
 	case errors.Is(err, os.ErrNotExist):
-		defaultPath, defaultErr := DefaultSessionFilePath()
-		if defaultErr == nil && path == defaultPath {
-			legacyPath, legacyErr := DefaultLegacySessionFilePath()
-			if legacyErr == nil && legacyPath != "" && legacyPath != path {
-				if legacySessionID, migrated, migrateErr := migrateLegacySessionID(legacyPath, path); migrateErr != nil {
-					return "", SessionSourceUnset, migrateErr
-				} else if migrated {
-					return legacySessionID, SessionSourceMigrated, nil
-				}
-			}
-		}
+		// Create below.
 	default:
 		return "", SessionSourceUnset, fmt.Errorf("read persistent MCP_XCODE_SESSION_ID from %s: %w", path, err)
 	}
@@ -116,24 +97,6 @@ func persistSessionID(path, sessionID string) error {
 		return fmt.Errorf("write persistent MCP_XCODE_SESSION_ID to %s: %w", path, err)
 	}
 	return nil
-}
-
-func migrateLegacySessionID(legacyPath, newPath string) (string, bool, error) {
-	data, err := os.ReadFile(legacyPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return "", false, nil
-	}
-	if err != nil {
-		return "", false, fmt.Errorf("read legacy MCP_XCODE_SESSION_ID from %s: %w", legacyPath, err)
-	}
-	sessionID := strings.TrimSpace(string(data))
-	if !IsValidUUID(sessionID) {
-		return "", false, nil
-	}
-	if err := persistSessionID(newPath, sessionID); err != nil {
-		return "", false, err
-	}
-	return sessionID, true, nil
 }
 
 func resolveSessionFilePath(homeDir, supportDirName string) string {

--- a/internal/bridge/session_test.go
+++ b/internal/bridge/session_test.go
@@ -104,45 +104,6 @@ func TestResolveOptionsRepairsInvalidPersistedSessionID(t *testing.T) {
 	}
 }
 
-func TestResolveOptionsMigratesLegacyPersistedSessionID(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-
-	legacyPath, err := DefaultLegacySessionFilePath()
-	if err != nil {
-		t.Fatalf("DefaultLegacySessionFilePath returned error: %v", err)
-	}
-	newPath, err := DefaultSessionFilePath()
-	if err != nil {
-		t.Fatalf("DefaultSessionFilePath returned error: %v", err)
-	}
-	want := "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
-	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
-		t.Fatalf("MkdirAll failed: %v", err)
-	}
-	if err := os.WriteFile(legacyPath, []byte(want+"\n"), 0o600); err != nil {
-		t.Fatalf("WriteFile failed: %v", err)
-	}
-
-	resolved, err := ResolveOptions(nil, EnvOptions{}, newPath)
-	if err != nil {
-		t.Fatalf("ResolveOptions returned error: %v", err)
-	}
-	if resolved.SessionID != want {
-		t.Fatalf("SessionID = %q, want %q", resolved.SessionID, want)
-	}
-	if resolved.SessionSource != SessionSourceMigrated {
-		t.Fatalf("SessionSource = %q, want %q", resolved.SessionSource, SessionSourceMigrated)
-	}
-	data, err := os.ReadFile(newPath)
-	if err != nil {
-		t.Fatalf("ReadFile(%q) failed: %v", newPath, err)
-	}
-	if got := string(data); got != want+"\n" {
-		t.Fatalf("persisted session content = %q, want %q", got, want+"\n")
-	}
-}
-
 func TestNewUUIDReturnsValidUUID(t *testing.T) {
 	value, err := NewUUID()
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -238,9 +238,6 @@ func (i Inspector) Run(ctx context.Context, opts Options) Report {
 		if opts.AgentStatus.RegisteredBinary != "" || opts.AgentStatus.CurrentBinary != "" {
 			checks = append(checks, Check{Name: "LaunchAgent binary registration", Status: StatusInfo, Detail: fmt.Sprintf("registered=%s | current=%s | match=%t", opts.AgentStatus.RegisteredBinary, opts.AgentStatus.CurrentBinary, opts.AgentStatus.BinaryPathMatches)})
 		}
-		checks = append(checks, Check{Name: "Legacy LaunchAgent plist", Status: StatusInfo, Detail: fmt.Sprintf("installed=%t path=%s", opts.AgentStatus.Legacy.PlistInstalled, opts.AgentStatus.Legacy.PlistPath)})
-		checks = append(checks, Check{Name: "Legacy support directory", Status: StatusInfo, Detail: fmt.Sprintf("exists=%t path=%s", opts.AgentStatus.Legacy.SupportDirExists, opts.AgentStatus.Legacy.SupportDir)})
-		checks = append(checks, Check{Name: "Legacy session file", Status: StatusInfo, Detail: fmt.Sprintf("exists=%t path=%s", opts.AgentStatus.Legacy.SessionFileExists, opts.AgentStatus.Legacy.SessionPath)})
 	}
 
 	return Report{Checks: checks}
@@ -255,10 +252,6 @@ func formatSessionDetail(opts Options) string {
 	case bridge.SessionSourceGenerated:
 		if opts.SessionPath != "" {
 			return fmt.Sprintf("%s (generated and saved to %s)", opts.SessionID, opts.SessionPath)
-		}
-	case bridge.SessionSourceMigrated:
-		if opts.SessionPath != "" {
-			return fmt.Sprintf("%s (migrated from legacy xcodemcp storage into %s)", opts.SessionID, opts.SessionPath)
 		}
 	case bridge.SessionSourceEnv:
 		return fmt.Sprintf("%s (from environment)", opts.SessionID)

--- a/scripts/release_homebrew.sh
+++ b/scripts/release_homebrew.sh
@@ -7,7 +7,6 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 
 TAP_REPO="oozoofrog/homebrew-tap"
 FORMULA_NAME="xcodecli"
-LEGACY_FORMULA_NAME="xcodemcp"
 DEFAULT_CLONE_ROOT="${TMPDIR:-/tmp}"
 
 usage() {
@@ -22,9 +21,8 @@ Examples:
 Behavior:
   - Downloads the GitHub source tarball for the given tag
   - Computes sha256 and writes Formula/xcodecli.rb in the shared tap repo
-  - Removes Formula/xcodemcp.rb during the rename cutover
   - Runs Homebrew audit and build-from-source validation
-  - Commits the xcodecli formula add/update plus any xcodemcp formula removal unless --dry-run is set
+  - Commits only the xcodecli formula change locally unless --dry-run is set
   - Pushes the tap commit only when --push is set
 
 Environment:
@@ -69,7 +67,6 @@ ensure_git_identity() {
 ensure_tap_repo_safe() {
   local tap_dir="$1"
   local formula_rel="Formula/${FORMULA_NAME}.rb"
-  local legacy_formula_rel="Formula/${LEGACY_FORMULA_NAME}.rb"
   local status
   status="$(git -C "$tap_dir" status --short)"
   if [[ -z "$status" ]]; then
@@ -79,7 +76,7 @@ ensure_tap_repo_safe() {
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     local path_part="${line:3}"
-    if [[ "$path_part" != "$formula_rel" && "$path_part" != "$legacy_formula_rel" ]]; then
+    if [[ "$path_part" != "$formula_rel" ]]; then
       fail "tap repo has unrelated local changes: $line"
     fi
   done <<< "$status"
@@ -169,7 +166,6 @@ fi
 ensure_tap_repo_safe "$TAP_DIR"
 mkdir -p "$TAP_DIR/Formula"
 FORMULA_PATH="$TAP_DIR/Formula/${FORMULA_NAME}.rb"
-LEGACY_FORMULA_PATH="$TAP_DIR/Formula/${LEGACY_FORMULA_NAME}.rb"
 TARBALL_URL="https://github.com/${SOURCE_REPO}/archive/refs/tags/${TAG}.tar.gz"
 
 log "computing sha256 for ${TARBALL_URL}"
@@ -178,10 +174,6 @@ SHA256="$(curl -fsSL "$TARBALL_URL" | shasum -a 256 | awk '{print $1}')"
 
 log "writing ${FORMULA_PATH} inside shared tap repo ${TAP_DIR}"
 render_formula "$VERSION" "$SHA256" > "$FORMULA_PATH"
-if [[ -f "$LEGACY_FORMULA_PATH" ]]; then
-  log "removing legacy formula ${LEGACY_FORMULA_PATH}"
-  rm -f "$LEGACY_FORMULA_PATH"
-fi
 
 VALIDATION_TAP_ADDED=0
 if ! brew tap | grep -qx "$TAP_NAME"; then
@@ -238,7 +230,7 @@ if [[ "$WAS_INSTALLED" -eq 0 ]]; then
   brew uninstall --force "$FORMULA_NAME"
 fi
 
-if [[ -z "$(git -C "$TAP_DIR" status --short -- "Formula/${FORMULA_NAME}.rb" "Formula/${LEGACY_FORMULA_NAME}.rb")" ]]; then
+if [[ -z "$(git -C "$TAP_DIR" status --short -- "Formula/${FORMULA_NAME}.rb")" ]]; then
   log "formula already up to date"
 else
   if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -246,7 +238,7 @@ else
   else
     ensure_git_identity "$TAP_DIR"
     ensure_tap_repo_safe "$TAP_DIR"
-    git -C "$TAP_DIR" add -A "Formula/${FORMULA_NAME}.rb" "Formula/${LEGACY_FORMULA_NAME}.rb"
+    git -C "$TAP_DIR" add "Formula/${FORMULA_NAME}.rb"
     git -C "$TAP_DIR" commit -m "${FORMULA_NAME} ${VERSION}"
     if [[ "$PUSH" -eq 1 ]]; then
       log "rebasing tap branch before push"


### PR DESCRIPTION
## Summary
- remove legacy migration/rename language from docs, changelog, release tooling, and status output
- simplify the runtime/session code so `xcodecli` only presents the current runtime model
- keep the published release notes aligned with the current product story

## Testing
- go test ./...
- ./scripts/build.sh
- ./xcodecli --help