### PR TITLE
Show version in root help output

### DIFF
--- a/cmd/xcodecli/cli.go
+++ b/cmd/xcodecli/cli.go
@@ -531,7 +531,9 @@ func newFlagSet(name string) *flag.FlagSet {
 }
 
 func rootUsage() string {
-	return `xcodecli wraps xcrun mcpbridge for local macOS use.
+	return versionLine() + `
+
+xcodecli wraps xcrun mcpbridge for local macOS use.
 
 START HERE:
   For humans:

--- a/cmd/xcodecli/main_test.go
+++ b/cmd/xcodecli/main_test.go
@@ -57,13 +57,18 @@ func TestParseCLIVersionFlag(t *testing.T) {
 }
 
 func TestParseCLIWithoutArgsShowsHelp(t *testing.T) {
-	_, usage, err := parseCLI(nil)
-	if err != errUsageRequested {
-		t.Fatalf("err = %v, want errUsageRequested", err)
-	}
-	if !strings.Contains(usage, "START HERE:") {
-		t.Fatalf("usage missing root help banner: %q", usage)
-	}
+	withVersionState(t, "v1.2.3", "dev", func() {
+		_, usage, err := parseCLI(nil)
+		if err != errUsageRequested {
+			t.Fatalf("err = %v, want errUsageRequested", err)
+		}
+		if !strings.Contains(usage, "START HERE:") {
+			t.Fatalf("usage missing root help banner: %q", usage)
+		}
+		if !strings.HasPrefix(usage, "xcodecli v1.2.3 (dev)\n\n") {
+			t.Fatalf("usage missing version header: %q", usage)
+		}
+	})
 }
 
 func TestParseCLIDoctorJSON(t *testing.T) {
@@ -153,12 +158,14 @@ func TestParseCLIHelp(t *testing.T) {
 }
 
 func TestRootUsageIncludesHumanAndAgentGuidance(t *testing.T) {
-	usage := rootUsage()
-	for _, want := range []string{"START HERE:", "For humans:", "For agents:", "xcodecli version", "xcodecli agent guide", "xcodecli agent demo", "xcodecli doctor --json", "xcodecli tool inspect <name> --json"} {
-		if !strings.Contains(usage, want) {
-			t.Fatalf("root usage missing %q: %s", want, usage)
+	withVersionState(t, "v9.9.9", "dev", func() {
+		usage := rootUsage()
+		for _, want := range []string{"xcodecli v9.9.9 (dev)", "START HERE:", "For humans:", "For agents:", "xcodecli version", "xcodecli agent guide", "xcodecli agent demo", "xcodecli doctor --json", "xcodecli tool inspect <name> --json"} {
+			if !strings.Contains(usage, want) {
+				t.Fatalf("root usage missing %q: %s", want, usage)
+			}
 		}
-	}
+	})
 }
 
 func TestVersionUsageMentionsVersionFlag(t *testing.T) {
@@ -199,7 +206,7 @@ func TestRunRejectsInvalidBridgeOptions(t *testing.T) {
 }
 
 func TestRunVersionCommand(t *testing.T) {
-	withVersion(t, "v9.9.9", func() {
+	withVersionState(t, "v9.9.9", "release", func() {
 		var stdout strings.Builder
 		var stderr strings.Builder
 		code := run(context.Background(), []string{"version"}, strings.NewReader(""), &stdout, &stderr, os.Environ())
@@ -216,7 +223,7 @@ func TestRunVersionCommand(t *testing.T) {
 }
 
 func TestRunVersionFlag(t *testing.T) {
-	withVersion(t, "v1.2.3", func() {
+	withVersionState(t, "v1.2.3", "release", func() {
 		var stdout strings.Builder
 		var stderr strings.Builder
 		code := run(context.Background(), []string{"--version"}, strings.NewReader(""), &stdout, &stderr, os.Environ())
@@ -229,10 +236,35 @@ func TestRunVersionFlag(t *testing.T) {
 	})
 }
 
-func TestCurrentVersionFallsBackToDev(t *testing.T) {
-	withVersion(t, "", func() {
-		if got := currentVersion(); got != "dev" {
-			t.Fatalf("currentVersion() = %q, want dev", got)
+func TestRunHelpShowsVersionHeader(t *testing.T) {
+	withVersionState(t, "v2.0.0", "dev", func() {
+		var stdout strings.Builder
+		var stderr strings.Builder
+		code := run(context.Background(), []string{"help"}, strings.NewReader(""), &stdout, &stderr, os.Environ())
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0", code)
+		}
+		if !strings.HasPrefix(stdout.String(), "xcodecli v2.0.0 (dev)\n\n") {
+			t.Fatalf("stdout = %q, want version header", stdout.String())
+		}
+		if stderr.String() != "" {
+			t.Fatalf("stderr = %q, want empty stderr", stderr.String())
+		}
+	})
+}
+
+func TestCurrentVersionFallsBackToSourceVersion(t *testing.T) {
+	withVersionState(t, "", "dev", func() {
+		if got := currentVersion(); got != sourceVersion {
+			t.Fatalf("currentVersion() = %q, want %q", got, sourceVersion)
+		}
+	})
+}
+
+func TestVersionLineMarksDevBuilds(t *testing.T) {
+	withVersionState(t, "v1.2.3", "dev", func() {
+		if got := versionLine(); got != "xcodecli v1.2.3 (dev)" {
+			t.Fatalf("versionLine() = %q, want dev marker", got)
 		}
 	})
 }
@@ -678,10 +710,15 @@ func withStubs(t *testing.T, fn func()) {
 	fn()
 }
 
-func withVersion(t *testing.T, version string, fn func()) {
+func withVersionState(t *testing.T, version string, buildChannel string, fn func()) {
 	t.Helper()
-	old := cliVersion
+	oldVersion := cliVersion
+	oldBuildChannel := cliBuildChannel
 	cliVersion = version
-	defer func() { cliVersion = old }()
+	cliBuildChannel = buildChannel
+	defer func() {
+		cliVersion = oldVersion
+		cliBuildChannel = oldBuildChannel
+	}()
 	fn()
 }

--- a/cmd/xcodecli/version.go
+++ b/cmd/xcodecli/version.go
@@ -2,16 +2,23 @@ package main
 
 import "strings"
 
-var cliVersion = "dev"
+const sourceVersion = "v0.3.1"
+
+var cliVersion = sourceVersion
+var cliBuildChannel = "dev"
 
 func currentVersion() string {
 	version := strings.TrimSpace(cliVersion)
 	if version == "" {
-		return "dev"
+		return sourceVersion
 	}
 	return version
 }
 
 func versionLine() string {
-	return "xcodecli " + currentVersion()
+	line := "xcodecli " + currentVersion()
+	if strings.EqualFold(strings.TrimSpace(cliBuildChannel), "dev") {
+		line += " (dev)"
+	}
+	return line
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,19 +4,22 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE="${PACKAGE:-./cmd/xcodecli}"
 OUTPUT="${1:-${OUTPUT:-${ROOT_DIR}/xcodecli}}"
-VERSION="${VERSION:-dev}"
+SOURCE_VERSION="$(sed -n 's/^const sourceVersion = "\(.*\)"$/\1/p' "${ROOT_DIR}/cmd/xcodecli/version.go" | head -n 1)"
+VERSION="${VERSION:-${SOURCE_VERSION:-v0.0.0}}"
+BUILD_CHANNEL="${BUILD_CHANNEL:-dev}"
 GO_LDFLAGS="${GO_LDFLAGS:-}"
 
 if [[ -n "$GO_LDFLAGS" ]]; then
   GO_LDFLAGS="${GO_LDFLAGS} "
 fi
-GO_LDFLAGS="${GO_LDFLAGS}-X main.cliVersion=${VERSION}"
+GO_LDFLAGS="${GO_LDFLAGS}-X main.cliVersion=${VERSION} -X main.cliBuildChannel=${BUILD_CHANNEL}"
 
 mkdir -p "$(dirname "$OUTPUT")"
 
 echo "[build] package: ${PACKAGE}"
 echo "[build] output:  ${OUTPUT}"
 echo "[build] version: ${VERSION}"
+echo "[build] channel: ${BUILD_CHANNEL}"
 
 cd "$ROOT_DIR"
 go build -ldflags "$GO_LDFLAGS" -o "$OUTPUT" "$PACKAGE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -281,9 +281,9 @@ TEMP_OUTPUT="${WORK_DIR:-${TMPDIR:-/tmp}}/xcodecli"
 rm -f "$TEMP_OUTPUT"
 log "building xcodecli"
 if [[ -n "$REF" && "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  env VERSION="$REF" "${BUILD_ROOT}/scripts/build.sh" "$TEMP_OUTPUT"
+  env VERSION="$REF" BUILD_CHANNEL=release "${BUILD_ROOT}/scripts/build.sh" "$TEMP_OUTPUT"
 else
-  env -u VERSION "${BUILD_ROOT}/scripts/build.sh" "$TEMP_OUTPUT"
+  env -u VERSION -u BUILD_CHANNEL "${BUILD_ROOT}/scripts/build.sh" "$TEMP_OUTPUT"
 fi
 
 INSTALL_PATH="${INSTALL_BIN_DIR}/xcodecli"

--- a/scripts/release_homebrew.sh
+++ b/scripts/release_homebrew.sh
@@ -96,7 +96,7 @@ class Xcodecli < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(output: bin/"xcodecli", ldflags: "-s -w -X main.cliVersion=v#{version}"), "./cmd/xcodecli"
+    system "go", "build", *std_go_args(output: bin/"xcodecli", ldflags: "-s -w -X main.cliVersion=v#{version} -X main.cliBuildChannel=release"), "./cmd/xcodecli"
   end
 
   test do


### PR DESCRIPTION
## Summary
- show the version string at the top of `xcodecli` and `xcodecli help` output
- display development builds as `<version> (dev)` while release builds keep the plain version string
- align build/install/release helpers and tests with the new version presentation

## Testing
- go test ./cmd/xcodecli/... ./internal/...
- ./xcodecli
- ./xcodecli help
- ./xcodecli version
- VERSION=v9.9.9 BUILD_CHANNEL=release ./scripts/build.sh .tmp/xcodecli-release && ./.tmp/xcodecli-release version