### PR TITLE
Bump version to v1.2.1

### DIFF
--- a/Sources/XcodeCLICore/Shared/Version.swift
+++ b/Sources/XcodeCLICore/Shared/Version.swift
@@ -1,5 +1,5 @@
 public enum Version {
-    public static let source = "v1.2.0"
+    public static let source = "v1.2.1"
 
     /// Replaced at build time by scripts/build-swift.sh via sed.
     /// When building with `swift build` directly, stays equal to `source`.

--- a/cmd/xcodecli/version.go
+++ b/cmd/xcodecli/version.go
@@ -2,7 +2,7 @@ package main
 
 import "strings"
 
-const sourceVersion = "v1.2.0"
+const sourceVersion = "v1.2.1"
 
 var cliVersion = sourceVersion
 var cliBuildChannel = "dev"


### PR DESCRIPTION
## 요약
- source version을 `v1.2.1`로 업데이트했습니다.
- Swift/Go 버전 소스를 계속 동기화된 상태로 유지합니다.

## 변경 사항
- `Sources/XcodeCLICore/Shared/Version.swift`: `Version.source`를 `v1.2.1`로 변경
- `cmd/xcodecli/version.go`: `sourceVersion`을 `v1.2.1`로 변경

## 검증
- `bash ./scripts/check-version-sync.sh`
  - 결과: `[version-sync] ok: v1.2.1`

## 비고
- 이번 PR은 버전 범프만 포함하며, 기능 변경은 없습니다.